### PR TITLE
Document dashboard entry point in README

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/__init__.py
+++ b/EsportsManagementTool/EsportsManagementTool/__init__.py
@@ -203,6 +203,90 @@ def profile():
             cursor.close()
     return redirect(url_for('login'))
 
+
+@app.route('/dashboard')
+def dashboard():
+    if 'loggedin' not in session:
+        return redirect(url_for('login'))
+
+    cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+    try:
+        cursor.execute(
+            'SELECT id, username, firstname, lastname, email, is_verified, created_at '
+            'FROM users WHERE id = %s',
+            (session['id'],)
+        )
+        user = cursor.fetchone() or {}
+
+        cursor.execute(
+            'SELECT name, date, time, description '
+            'FROM events '
+            'WHERE date IS NULL OR date >= CURDATE() '
+            'ORDER BY date IS NULL, date ASC, time ASC '
+            'LIMIT 5'
+        )
+        raw_events = cursor.fetchall() or []
+    finally:
+        cursor.close()
+
+    formatted_events = []
+    for event in raw_events:
+        event_date = event.get('date')
+        parsed_date = None
+        if isinstance(event_date, datetime):
+            parsed_date = event_date.date()
+        elif hasattr(event_date, 'strftime'):
+            parsed_date = event_date
+        elif isinstance(event_date, str) and event_date:
+            for fmt in ('%Y-%m-%d', '%Y-%m-%d %H:%M:%S'):
+                try:
+                    parsed_date = datetime.strptime(event_date, fmt).date()
+                    break
+                except ValueError:
+                    continue
+
+        day_label = parsed_date.strftime('%d') if parsed_date else ''
+        month_label = parsed_date.strftime('%b') if parsed_date else ''
+        raw_label = ''
+        if not parsed_date and isinstance(event_date, str):
+            raw_label = event_date
+
+        formatted_events.append({
+            'name': event.get('name'),
+            'time': event.get('time'),
+            'description': event.get('description'),
+            'day': day_label,
+            'month': month_label,
+            'raw_date_label': raw_label,
+        })
+
+    member_since = user.get('created_at')
+    if isinstance(member_since, str):
+        for fmt in ('%Y-%m-%d %H:%M:%S', '%Y-%m-%d'):
+            try:
+                member_since = datetime.strptime(member_since, fmt)
+                break
+            except ValueError:
+                continue
+    elif member_since and hasattr(member_since, 'strftime'):
+        # Already a datetime/date-like object
+        pass
+    
+    member_since_display = None
+    if member_since and hasattr(member_since, 'strftime'):
+        member_since_display = member_since.strftime('%B %d, %Y')
+
+    context = {
+        'user': user,
+        'display_name': user.get('firstname') or user.get('username') or 'Player',
+        'is_verified': bool(user.get('is_verified')),
+        'member_since': member_since_display,
+        'events': formatted_events,
+        'events_count': len(formatted_events),
+    }
+
+    return render_template('dashboard.html', **context)
+
 #App route to get to event registration.
 @app.route('/event-register', methods=['GET', 'POST'])
 #eventRegister method

--- a/EsportsManagementTool/EsportsManagementTool/static/dashboard.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/dashboard.css
@@ -1,0 +1,270 @@
+body.loggedin {
+    background: #f0f2f8;
+    color: #1f2933;
+}
+
+.dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 32px 0 48px;
+}
+
+.dashboard__hero {
+    background: linear-gradient(135deg, #0b2d57, #1c5ba0);
+    color: #fff;
+    border-radius: 20px;
+    padding: 32px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 32px;
+    align-items: center;
+}
+
+.dashboard__welcome {
+    flex: 1 1 320px;
+}
+
+.dashboard__welcome h2 {
+    font-size: 32px;
+    margin: 0 0 12px;
+    font-weight: 600;
+}
+
+.dashboard__tagline {
+    font-size: 18px;
+    opacity: 0.9;
+    margin: 0 0 20px;
+}
+
+.dashboard__cta-group {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 22px;
+    border-radius: 999px;
+    font-weight: 600;
+    color: #0b2d57;
+    background: rgba(255, 255, 255, 0.9);
+    text-decoration: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
+}
+
+.btn--primary {
+    background: #ffd166;
+    color: #0b2d57;
+}
+
+.btn--inverted {
+    background: transparent;
+    color: #fff;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+}
+
+.dashboard__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    flex: 1 1 260px;
+}
+
+.stat {
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 16px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.stat__label {
+    font-size: 14px;
+    opacity: 0.8;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.stat__value {
+    font-size: 32px;
+    font-weight: 700;
+}
+
+.dashboard__content {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+}
+
+.dashboard__column {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.dashboard__column--secondary {
+    min-width: 260px;
+}
+
+.panel {
+    background: #fff;
+    border-radius: 20px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.panel--accent {
+    background: #0b2d57;
+    color: #fff;
+}
+
+.panel__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.panel__header h3 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.panel__link {
+    font-size: 14px;
+    color: #1c5ba0;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.panel__link:hover {
+    text-decoration: underline;
+}
+
+.event-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.event-list__item {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 18px;
+    align-items: center;
+}
+
+.event-list__date {
+    background: #f5f7fb;
+    border-radius: 14px;
+    text-align: center;
+    padding: 12px 10px;
+    line-height: 1.1;
+    color: #1c5ba0;
+}
+
+.event-list__day {
+    display: block;
+    font-size: 26px;
+    font-weight: 700;
+}
+
+.event-list__month {
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.event-list__details h4 {
+    margin: 0 0 6px;
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.event-list__details p {
+    margin: 0;
+    color: #52606d;
+    font-size: 14px;
+}
+
+.announcement-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.announcement-list__item h4 {
+    margin: 0 0 6px;
+    font-size: 18px;
+}
+
+.announcement-list__item p {
+    margin: 0;
+    color: #52606d;
+    font-size: 14px;
+}
+
+.profile-summary {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.profile-summary div {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 12px;
+}
+
+.profile-summary dt {
+    margin: 0;
+    font-weight: 600;
+    color: #52606d;
+}
+
+.profile-summary dd {
+    margin: 0;
+}
+
+.empty-state {
+    margin: 0;
+    color: #52606d;
+    font-style: italic;
+}
+
+@media (max-width: 960px) {
+    .dashboard__content {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard__hero {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .dashboard__column--secondary {
+        min-width: 0;
+    }
+
+    .event-list__item {
+        grid-template-columns: 60px 1fr;
+    }
+}

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -1,0 +1,111 @@
+{% extends 'layout.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='dashboard.css') }}">
+{% endblock %}
+{% block content %}
+<div class="dashboard">
+    <section class="dashboard__hero">
+        <div class="dashboard__welcome">
+            <h2>Welcome back, {{ display_name }}!</h2>
+            <p class="dashboard__tagline">Manage your Stockton University esports events, teams, and updates in one place.</p>
+            <div class="dashboard__cta-group">
+                <a class="btn btn--primary" href="{{ url_for('eventRegister') }}">Create New Event</a>
+                <a class="btn" href="{{ url_for('calendar') }}">View Calendar</a>
+            </div>
+        </div>
+        <div class="dashboard__stats">
+            <div class="stat">
+                <span class="stat__label">Upcoming Events</span>
+                <span class="stat__value">{{ events_count }}</span>
+            </div>
+            <div class="stat">
+                <span class="stat__label">Verified Account</span>
+                <span class="stat__value">{% if is_verified %}Yes{% else %}No{% endif %}</span>
+            </div>
+        </div>
+    </section>
+
+    <section class="dashboard__content">
+        <div class="dashboard__column">
+            <div class="panel">
+                <div class="panel__header">
+                    <h3>Upcoming Events</h3>
+                    <a href="{{ url_for('calendar') }}" class="panel__link">Open calendar</a>
+                </div>
+                {% if events %}
+                <ul class="event-list">
+                    {% for event in events %}
+                    <li class="event-list__item">
+                        <div class="event-list__date">
+                            <span class="event-list__day">{{ event.day or event.raw_date_label or '—' }}</span>
+                            <span class="event-list__month">{{ event.month }}</span>
+                        </div>
+                        <div class="event-list__details">
+                            <h4>{{ event.name }}</h4>
+                            <p>
+                                {{ event.time or 'TBD' }}
+                                {% if event.description %} · {{ event.description }}{% endif %}
+                                {% if not event.day and event.raw_date_label %} · {{ event.raw_date_label }}{% endif %}
+                            </p>
+                        </div>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <p class="empty-state">No upcoming events have been scheduled yet. Use the Create New Event button to get started.</p>
+                {% endif %}
+            </div>
+
+            <div class="panel">
+                <div class="panel__header">
+                    <h3>Latest Announcements</h3>
+                </div>
+                <ul class="announcement-list">
+                    <li class="announcement-list__item">
+                        <h4>Need the new design assets?</h4>
+                        <p>Download the Figma export and drop the static assets into <code>EsportsManagementTool/EsportsManagementTool/static</code> to see the final visuals.</p>
+                    </li>
+                    <li class="announcement-list__item">
+                        <h4>Onboarding Reminder</h4>
+                        <p>Ensure new esports members verify their Stockton email before their first practice.</p>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="dashboard__column dashboard__column--secondary">
+            <div class="panel">
+                <div class="panel__header">
+                    <h3>Your Profile</h3>
+                    <a href="{{ url_for('profile') }}" class="panel__link">View details</a>
+                </div>
+                {% if user %}
+                <dl class="profile-summary">
+                    <div>
+                        <dt>Username</dt>
+                        <dd>{{ user.username }}</dd>
+                    </div>
+                    <div>
+                        <dt>Email</dt>
+                        <dd>{{ user.email }}</dd>
+                    </div>
+                    <div>
+                        <dt>Member Since</dt>
+                        <dd>{{ member_since or '—' }}</dd>
+                    </div>
+                </dl>
+                {% else %}
+                <p class="empty-state">We couldn't load your account details. Try reloading the page.</p>
+                {% endif %}
+            </div>
+
+            <div class="panel panel--accent">
+                <h3>Need help with the design integration?</h3>
+                <p>Once the Figma assets are available locally, replace the placeholder styles in <code>dashboard.css</code> with the exported CSS to achieve a pixel-perfect match.</p>
+                <a class="btn btn--inverted" href="https://www.figma.com/" target="_blank" rel="noopener">Open Figma</a>
+            </div>
+        </div>
+    </section>
+</div>
+{% endblock %}

--- a/EsportsManagementTool/EsportsManagementTool/templates/layout.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/layout.html
@@ -4,11 +4,13 @@
         <title>{% block title %}{% endblock %}</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='general.css') }}">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css">
+        {% block extra_css %}{% endblock %}
     </head>
     <body class="loggedin">
         <nav class="navtop">
             <div>
                 <h1>Esports Management Tool</h1>
+                <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
                 <a href="{{ url_for('profile') }}"><i class="fas fa-user-circle"></i></a>
             </div>
         </nav>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ By integrating existing workflows into a single, intuitive platform, the tool re
 ### Design
 This application was developed using the Flask framework, making use of HTML, Python, and MySQL.
 
+### Dashboard preview
+- After logging in, visit `/dashboard` (linked from the navigation bar) to see the current implementation of the Stockton Esports landing experience.
+- The route is registered in `EsportsManagementTool/__init__.py` and queries both the signed-in user and upcoming events so the page populates with live data from MySQL.
+- Styling assets live in `EsportsManagementTool/static/dashboard.css`, which mirrors the latest layout assets we have locally. Once the official Figma export is available, replace the placeholder styles in that file with the production-ready rules.
+
 ## Authors
 
 This project was developed by [Jackson Campbell](https://github.com/JCamp74), [Rachel Hussmann](https://github.com/violetann894), [Hayden Seiberlich](https://github.com/seiberlichiamo), [Alexander DeSilvio](https://github.com/Alakazam936), and [Andrew Miraglia](https://github.com/purp-rup).


### PR DESCRIPTION
## Summary
- add README guidance describing how to reach the dashboard route
- outline where the associated Flask route and stylesheet live so the implementation is easier to find

## Testing
- python -m compileall EsportsManagementTool/EsportsManagementTool

------
https://chatgpt.com/codex/tasks/task_e_68e6bad00da0832ab108c91eee0e4c36