### PR TITLE
Add match details modal to team stats dashboard

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/static/teamstats.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teamstats.css
@@ -156,11 +156,13 @@
     border: 1px solid var(--border-color);
     border-radius: 8px;
     transition: all 0.2s;
+    cursor: pointer; 
 }
 
 .match-history-item:hover {
     border-color: var(--stockton-blue);
     box-shadow: 0 2px 8px rgba(121, 189, 233, 0.2);
+    transform: translateY(-1px); 
 }
 
 .match-date {
@@ -385,4 +387,134 @@
     .result-options {
         grid-template-columns: 1fr;
     }
+}
+/* ============================================
+   MATCH DETAILS MODAL
+   ============================================ */
+
+.match-details-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.match-detail-section {
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.match-detail-section.full-width {
+    grid-column: 1 / -1;
+}
+
+.match-detail-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.match-detail-label i {
+    color: var(--stockton-blue);
+}
+
+.match-detail-value {
+    font-size: 1rem;
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.match-detail-result {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 0.9375rem;
+}
+
+.match-detail-result.win {
+    background: rgba(76, 175, 80, 0.1);
+    color: #4caf50;
+    border: 2px solid #4caf50;
+}
+
+.match-detail-result.loss {
+    background: rgba(244, 67, 54, 0.1);
+    color: #f44336;
+    border: 2px solid #f44336;
+}
+
+.match-detail-result.pending {
+    background: rgba(255, 152, 0, 0.1);
+    color: #ff9800;
+    border: 2px solid #ff9800;
+}
+
+.match-detail-notes {
+    background: var(--background-secondary);
+    border-left: 3px solid var(--stockton-blue);
+    padding: 1rem;
+    border-radius: 4px;
+    font-style: italic;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.match-detail-metadata {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.match-detail-metadata-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.match-detail-metadata-item i {
+    color: var(--stockton-blue);
+    width: 16px;
+}
+
+/* Action buttons in modal */
+.btn-icon-action {
+    background: transparent;
+    border: 2px solid var(--border-color);
+    color: var(--text-secondary);
+    width: 36px;
+    height: 36px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-icon-action:hover {
+    background: var(--hover-bg);
+    border-color: var(--stockton-blue);
+    color: var(--stockton-blue);
+}
+
+.btn-icon-edit:hover {
+    border-color: var(--stockton-blue);
+    color: var(--stockton-blue);
+}
+
+.btn-icon-delete:hover {
+    border-color: #f44336;
+    color: #f44336;
 }

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -1817,7 +1817,6 @@
         </div>
         <div class="modal-body">
             <p class="modal-subtitle">Record the outcome of a past match</p>
-
             <form id="recordMatchResultForm" class="event-form-modal" onsubmit="submitMatchResult(event)">
                 <!-- Match Selection -->
                 <div class="form-group">
@@ -1876,6 +1875,36 @@
                     </button>
                 </div>
             </form>
+        </div>
+    </div>
+</div>
+
+<!-- Match Details Modal -->
+<div id="matchDetailsModal" class="modal">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 id="matchDetailsTitle">Match Details</h2>
+            <div style="display: flex; gap: 0.5rem; align-items: center;">
+                <button id="editMatchDetailsBtn"
+                        class="btn-icon-action btn-icon-edit"
+                        style="display: none;"
+                        title="Edit Result">
+                    <i class="fas fa-edit"></i>
+                </button>
+                <button class="modal-close" onclick="closeMatchDetailsModal()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+        </div>
+        <div class="modal-body">
+            <div id="matchDetailsLoading" class="loading-spinner" style="text-align: center; padding: 2rem;">
+                <i class="fas fa-spinner fa-spin" style="font-size: 2rem; color: var(--stockton-blue);"></i>
+                <p style="color: var(--text-secondary); margin-top: 1rem;">Loading match details...</p>
+            </div>
+
+            <div id="matchDetailsContent" style="display: none;">
+                <!-- Match details will be populated here -->
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Introduces a modal for viewing detailed match information in the team stats dashboard. Updates CSS for modal styling, enhances match history items to open the modal on click, and implements JavaScript logic to fetch and display match details, including result, notes, and metadata. Also updates dashboard.html to include the modal structure.