### PR TITLE
Add playoffs support and match-type badge to UI and backend

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/static/teamstats.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teamstats.css
@@ -613,6 +613,27 @@
 }
 
 /* ============================================
+   MATCH TYPE BADGES (Playoffs / Regular Season)
+   ============================================ */
+
+.match-type-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.match-type-badge-playoffs {
+    background: rgba(121, 189, 233, 0.1);
+    border: 1px solid rgba(121, 189, 233, 0.4);
+    color: var(--stockton-blue);
+}
+
+
+/* ============================================
    RESPONSIVE DESIGN
    ============================================ */
 

--- a/EsportsManagementTool/EsportsManagementTool/static/teamstats.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teamstats.js
@@ -62,6 +62,14 @@ let currentLeagueFilter = null;
  * @type {Array}
  */
 let availableLeagues = [];
+
+/**
+ * Event ID to re-open in matchDetailsModal after editing from that modal.
+ * Set when the edit button inside matchDetailsModal is clicked; cleared after use.
+ * @type {number|null}
+ */
+let pendingDetailsReopenEventId = null;
+
 // ============================================
 // STATS TAB LOADING
 // ============================================
@@ -424,6 +432,8 @@ function closeRecordResultModal() {
         modal.style.display = 'none';
         document.body.style.overflow = 'auto';
     }
+    // Clear any pending details re-open (e.g. user cancelled the edit)
+    pendingDetailsReopenEventId = null;
 }
 
 /**
@@ -573,7 +583,15 @@ async function submitMatchResult(event) {
             setTimeout(() => {
                 closeRecordResultModal();
                 // Reload stats tab to show updated data
-                loadStatsTab(currentStatsTeamId, currentStatsGameId);
+                loadStatsTab(currentStatsTeamId, currentStatsGameId).then(() => {
+                    // If edit was triggered from the details modal, re-open it
+                    // so the user sees the refreshed data straight away
+                    if (pendingDetailsReopenEventId !== null) {
+                        const reopenId = pendingDetailsReopenEventId;
+                        pendingDetailsReopenEventId = null;
+                        openMatchDetailsModal(reopenId);
+                    }
+                });
             }, 1500);
         } else {
             throw new Error(data.message);
@@ -899,6 +917,7 @@ async function openMatchDetailsModal(eventId) {
         if (editBtn && isGameManager && isActiveSeason && match.result) {
             editBtn.style.display = 'flex';
             editBtn.onclick = () => {
+                pendingDetailsReopenEventId = eventId;
                 closeMatchDetailsModal();
                 editMatchResult(eventId);
             };

--- a/EsportsManagementTool/EsportsManagementTool/static/teamstats.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teamstats.js
@@ -298,6 +298,11 @@ function renderMatchHistory() {
                           match.result === 'loss' ? 'fa-times-circle' :
                           'fa-clock';
         const resultText = match.result ? match.result.toUpperCase() : 'PENDING';
+        const playoffsBadge = match.is_playoffs ? `
+            <span class="match-playoffs-badge" title="Playoffs match">
+                <i class="fas fa-star"></i> Playoffs
+            </span>
+        ` : '';
 
         const leagueBadge = match.league_name ? `
             <span class="match-league-badge" title="League: ${match.league_name}">
@@ -527,7 +532,8 @@ async function submitMatchResult(event) {
         team_id: currentStatsTeamId,
         event_id: document.getElementById('matchEventSelect').value,
         result: document.querySelector('input[name="matchResult"]:checked')?.value,
-        notes: document.getElementById('matchNotes').value
+        notes: document.getElementById('matchNotes').value,
+        is_playoffs: document.getElementById('matchPlayoffs').checked
     };
 
     // ========================================
@@ -659,6 +665,12 @@ async function editMatchResult(eventId) {
     const notesField = document.getElementById('matchNotes');
     if (match.notes && notesField) {
         notesField.value = match.notes;
+    }
+
+    // Set playoffs checkbox if applicable
+    const playoffsCheckbox = document.getElementById('matchPlayoffs');
+    if (playoffsCheckbox) {
+        playoffsCheckbox.checked = match.is_playoffs || false;
     }
 }
 
@@ -819,6 +831,21 @@ async function openMatchDetailsModal(eventId) {
         // Title
         document.getElementById('matchDetailsTitle').textContent = match.name;
 
+
+        const playoffsHTML = match.is_playoffs ? `
+            <div class="match-detail-section">
+                <div class="match-detail-label">
+                    <i class="fas fa-star"></i>
+                    Match Type
+                </div>
+                <div class="match-detail-value">
+                    <span style="color: var(--stockton-blue); font-weight: 600;">
+                        <i class="fas fa-star"></i> Playoffs
+                    </span>
+                </div>
+            </div>
+        ` : '';
+
         // Render ONCE
         contentDiv.innerHTML = `
             <div class="match-details-grid">
@@ -857,6 +884,7 @@ async function openMatchDetailsModal(eventId) {
                 </div>
 
                 ${leagueHTML}
+                ${playoffsHTML}
                 ${notesHTML}
                 ${metadataHTML}
             </div>

--- a/EsportsManagementTool/EsportsManagementTool/team_stats.py
+++ b/EsportsManagementTool/EsportsManagementTool/team_stats.py
@@ -386,19 +386,21 @@ def register_team_stats_routes(app, mysql, login_required, roles_required, get_u
                 # Insert or update match result
                 cursor.execute("""
                     INSERT INTO match_results 
-                    (event_id, team_id, result, recorded_by, notes)
-                    VALUES (%s, %s, %s, %s, %s)
+                    (event_id, team_id, result, recorded_by, notes, is_playoffs)
+                    VALUES (%s, %s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
                         result = VALUES(result),
                         recorded_by = VALUES(recorded_by),
                         notes = VALUES(notes),
+                        is_playoffs = VALUES(is_playoffs),
                         recorded_at = CURRENT_TIMESTAMP
                 """, (
                     data['event_id'],
                     data['team_id'],
                     data['result'],
                     user_id,
-                    data.get('notes', '')
+                    data.get('notes', ''),
+                    data.get('is_playoffs', False)
                 ))
 
                 mysql.connection.commit()

--- a/EsportsManagementTool/EsportsManagementTool/team_stats.py
+++ b/EsportsManagementTool/EsportsManagementTool/team_stats.py
@@ -100,6 +100,7 @@ def register_team_stats_routes(app, mysql, login_required, roles_required, get_u
                             mr.result,
                             mr.notes,
                             mr.recorded_at,
+                            mr.is_playoffs,
                             u.firstname,
                             u.lastname
                         FROM generalevents ge
@@ -129,6 +130,7 @@ def register_team_stats_routes(app, mysql, login_required, roles_required, get_u
                             mr.result,
                             mr.notes,
                             mr.recorded_at,
+                            mr.is_playoffs,
                             u.firstname,
                             u.lastname
                         FROM generalevents ge
@@ -158,7 +160,8 @@ def register_team_stats_routes(app, mysql, login_required, roles_required, get_u
                         'result': match['result'],
                         'notes': match['notes'],
                         'recorded_at': match['recorded_at'].strftime('%Y-%m-%d %H:%M:%S') if match['recorded_at'] else None,
-                        'recorded_by': f"{match['firstname']} {match['lastname']}" if match['firstname'] else None
+                        'recorded_by': f"{match['firstname']} {match['lastname']}" if match['firstname'] else None,
+                        'is_playoffs': bool(match['is_playoffs']) if match['is_playoffs'] is not None else False
                     })
 
                 return jsonify({

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -1944,7 +1944,7 @@
                         Only past matches are shown. Future matches cannot have results recorded yet.
                     </small>
                 </div>
-
+                
                 <!-- Result Selection -->
                 <div class="form-group">
                     <label>Match Result *</label>
@@ -1965,6 +1965,23 @@
                             <span class="result-option-label">LOSS</span>
                         </label>
                     </div>
+                </div>
+                
+                <!-- Playoffs Checkbox -->
+                <div class="form-group" style="margin-top: 1rem;">
+                    <label style="display: flex; align-items: center; gap: 0.75rem; cursor: pointer;">
+                        <input type="checkbox"
+                            id="matchPlayoffs"
+                            name="is_playoffs"
+                            value="true"
+                            style="width: 1.1rem; height: 1.1rem; accent-color: var(--stockton-blue); cursor: pointer;">
+                        <span>
+                            <strong>Playoffs Match</strong>
+                            <small style="display: block; color: var(--text-secondary); font-size: 0.8125rem; margin-top: 0.15rem;">
+                                Check if this match was part of a playoff series
+                            </small>
+                        </span>
+                    </label>
                 </div>
 
                 <!-- Optional Notes -->


### PR DESCRIPTION
- Recording match results now includes a checkbox that will mark a match as playoffs or not
- Marking playoffs as false will cause nothing to change in the view match modal
- Marking playoffs as true creates an indicator that the match viewed is a playoffs match
- Edit functionality accounts for the new playoffs feature
- Listed some bugs I found in development (KAN-66, KAN-67)