### PR TITLE
Unit Test Instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,24 @@
 # Contributing to the Esports Management Tool
 
 ## Setup
-After cloning, you will need to create a virtual environment within the project to run the application. You can follow [these instructions](https://flask.palletsprojects.com/en/stable/installation/#create-an-environment).
-- You won't need to run the mkdir command after cloning, just right click the highlighted directory as shown in the image below *> Copy Path/Reference... > Absolute Path*, then continue with the cd command
-<p align="center">
-  <img width="390" height="344" alt="Directory to be selected" src="https://github.com/user-attachments/assets/2f32993e-fd39-4dae-b629-e7a516eb3f91" />
-</p>
-<br />
+After cloning, you will need to create a virtual environment within the project to run the application. The following instructions are for **Windows** machines&mdash;**MacOS/Linux** instructions can be found [here](https://flask.palletsprojects.com/en/stable/installation/#create-an-environment).
+<br/>
+<br/>
+Starting from the **project root**:
+```console
+cd EsportsManagementTool
+```
+```console
+py -3 -m venv .venv
+```
+```console
+.venv\Scripts\activate
+```
+
+Within the virtual environment, install **Flask**:
+```console
+pip install Flask
+```
 
 Next, **install dependencies**:
 ```console
@@ -20,6 +32,14 @@ Now, run in terminal:
 flask --app EsportsManagementTool run --debug
 ```
 
+## Testing
+Unit testing is primarily executed using **pytest**.
+<br/>
+<br/>
+After activating the virtual environment, run **tests** with:
+```console
+python -m pytest
+```
 
 ## When Committing...
 


### PR DESCRIPTION
## Completed KAN-62 Add Unit Test Instructions to CONTRIBUTING.md:
- Updated contributing instructions for setting up a virtual environment on Windows (made them more straightforward)
- Included a link to instructions for MacOS and Linux machines
- Added instructions for running unit tests