### PR TITLE
Refactored Email Management/Email Testing

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/__init__.py
+++ b/EsportsManagementTool/EsportsManagementTool/__init__.py
@@ -54,14 +54,35 @@ app.config['MYSQL_CUSTOM_OPTIONS'] = {
 }
 
 # Email Configuration (Brevo SMTP)
-app.config['MAIL_SERVER'] = 'smtp-relay.brevo.com'
-app.config['MAIL_PORT'] = 587
-app.config['MAIL_USE_TLS'] = True
-app.config['MAIL_USERNAME'] = os.environ.get('MAIL_USERNAME')
-app.config['MAIL_PASSWORD'] = os.environ.get('MAIL_PASSWORD')
-app.config['MAIL_DEFAULT_SENDER'] = os.environ.get('MAIL_DEFAULT_SENDER')
+class ProductionEmailConfig:
+    MAIL_SERVER = 'smtp-relay.brevo.com'
+    MAIL_PORT = 587
+    MAIL_USE_TLS = True
+    MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
+    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
+    MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER')
 
-# API Keys
+# Test Email Configuration (Mailpit)
+class TestingEmailConfig:
+    MAIL_SERVER = 'localhost'
+    MAIL_PORT = 1025
+    MAIL_USE_TLS = False
+    MAIL_USERNAME = None
+    MAIL_PASSWORD = None
+    MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER')
+
+# CHANGE THIS TO SWITCH MAILING MODES ('production' or 'testing')
+# Note: Testing mode will ONLY send emails to mailpit, make sure to revert to prod. mode when done testing!!!
+MAILING_MODE = 'testing'
+
+if MAILING_MODE == 'production':
+    app.config.from_object(ProductionEmailConfig)
+elif MAILING_MODE == 'testing':
+    app.config.from_object(TestingEmailConfig)
+else:
+    print("WARNING: No Email Mode Configured")
+
+# YouTube API Key
 app.config['YOUTUBE_API_KEY'] = os.environ.get('YOUTUBE_API_KEY')
 
 # Session Security (HTTPS enforcement)
@@ -769,6 +790,10 @@ tournament_results.register_tournament_results_routes(app, mysql, login_required
 # Initialize tournament notification scheduler
 from EsportsManagementTool import tournament_notification_scheduler
 tournament_notification_scheduler.initialize_tournament_scheduler(app, mysql, mail)
+
+# Initialize test mail server
+from EsportsManagementTool import email_manager
+email_manager.register_test_routes(app)
 
 # =======================================
 # CALENDAR API ENDPOINTS

--- a/EsportsManagementTool/EsportsManagementTool/__init__.py
+++ b/EsportsManagementTool/EsportsManagementTool/__init__.py
@@ -10,7 +10,7 @@ the packages format for modular organization.
 # =========================================
 from flask import Flask, render_template, request, redirect, url_for, session, flash, jsonify, make_response
 from flask_mysqldb import MySQL
-from flask_mail import Mail, Message
+from flask_mail import Mail
 from datetime import datetime, timedelta
 from functools import wraps
 import MySQLdb.cursors
@@ -350,65 +350,9 @@ def cleanup_inactive_users():
 
 
 # ============================================
-# EMAIL VERIFICATION
+# VERIFICATION EMAIL
 # ============================================
-def send_verify_email(email: str, token: str) -> None:
-    """
-    Send verification email to newly registered users.
-    Constructs and sends an email containing a verification link that
-    expires after 24 hours.
-    """
-    verify_url = url_for('verify_email', token=token, _external=True)
-    msg = Message('Verify Your Stockton University Email Account', recipients=[email])
-    msg.body = f'''Hello,
-Please click the link below to verify your Stockton Esports Management Tool account:
-
-{verify_url}
-
-This link will expire after 24 hours.
-
-If you did not create this account, please ignore this email.
-
-- EsMT Team.
-'''
-    mail.send(msg)
-
-
-@app.route('/verify/<token>')
-def verify_email(token: str):
-    """
-    Process email verification when user clicks verification link.
-    Verifies the token is valid and not expired, then marks the user's
-    account as verified in the database.
-
-    Returns:
-        Redirect to login page on success, or registration page on failure
-    """
-    cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
-    try:
-        # Look up token and check expiry
-        cursor.execute(
-            'SELECT * FROM verified_users WHERE verification_token = %s AND token_expiry > NOW()',
-            (token,)
-        )
-        user = cursor.fetchone()
-
-        if user:
-            # Mark user as verified and clear token
-            cursor.execute(
-                '''UPDATE verified_users 
-                   SET is_verified = TRUE, verification_token = NULL, token_expiry = NULL 
-                   WHERE userid = %s''',
-                (user['userid'],)
-            )
-            mysql.connection.commit()
-            flash('Email is successfully verified, welcome to Stockton Esports! You can now log in.', 'success')
-            return redirect(url_for('login'))
-        else:
-            flash('ERROR: Verification link is invalid/expired.', 'error')
-            return redirect(url_for('register'))
-    finally:
-        cursor.close()
+from EsportsManagementTool.email_manager import send_verify_email
 
 
 # ============================================
@@ -510,7 +454,7 @@ def login():
                         mysql.connection.commit()
 
                         try:
-                            send_verify_email(account['email'], verification_token)
+                            send_verify_email(account['email'], verification_token, username)
                             msg = 'Email sent.'
                         except Exception as e:
                             msg = f'Email failed to send. Error: {str(e)}'
@@ -732,7 +676,7 @@ def register():
                 mysql.connection.commit()
 
                 # Send verification email
-                send_verify_email(email, verification_token)
+                send_verify_email(email, verification_token, username)
                 msg = ('You have successfully created an account! Please check your email for verification! '
                        'If the email does not appear in your inbox, please check your spam!')
         finally:
@@ -791,9 +735,11 @@ tournament_results.register_tournament_results_routes(app, mysql, login_required
 from EsportsManagementTool import tournament_notification_scheduler
 tournament_notification_scheduler.initialize_tournament_scheduler(app, mysql, mail)
 
-# Initialize test mail server
+# Register verification email routes
 from EsportsManagementTool import email_manager
+email_manager.register_verification_routes(app, mysql)
 email_manager.register_test_routes(app)
+
 
 # =======================================
 # CALENDAR API ENDPOINTS

--- a/EsportsManagementTool/EsportsManagementTool/__init__.py
+++ b/EsportsManagementTool/EsportsManagementTool/__init__.py
@@ -73,7 +73,7 @@ class TestingEmailConfig:
 
 # CHANGE THIS TO SWITCH MAILING MODES ('production' or 'testing')
 # Note: Testing mode will ONLY send emails to mailpit, make sure to revert to prod. mode when done testing!!!
-MAILING_MODE = 'testing'
+MAILING_MODE = 'production'
 
 if MAILING_MODE == 'production':
     app.config.from_object(ProductionEmailConfig)

--- a/EsportsManagementTool/EsportsManagementTool/email_manager.py
+++ b/EsportsManagementTool/EsportsManagementTool/email_manager.py
@@ -4,8 +4,10 @@ This file verifies and sends all automatic emails & can test emails via Mailpit.
 """
 
 from EsportsManagementTool import app, mail
-from flask import url_for
+from flask import url_for, redirect, flash
 from flask_mail import Message
+from datetime import datetime
+import MySQLdb.cursors
 
 
 # =========================================
@@ -13,7 +15,7 @@ from flask_mail import Message
 # =========================================
 
 # Account Verification Email
-def send_verify_email(email: str, token: str) -> None:
+def send_verify_email(email: str, token: str, username: str) -> None:
     """
     Send verification email to newly registered users.
     Constructs and sends an email containing a verification link that
@@ -21,18 +23,92 @@ def send_verify_email(email: str, token: str) -> None:
     """
     verify_url = url_for('verify_email', token=token, _external=True)
     msg = Message('Verify Your Stockton University Email Account', recipients=[email])
-    msg.body = f'''Hello,
-Please click the link below to verify your Stockton Esports Management Tool account:
-
-{verify_url}
-
-This link will expire after 24 hours.
-
-If you did not create this account, please ignore this email.
-
-- EsMT Team.
-'''
+    msg.html = f'''
+        <div style="background-color: #f4f4f4; width: 100%; margin: 0; padding: 10px 0;">
+            <div style="background-color: #ffffff; max-width: 600px; margin: 0 auto;">
+                <div style="margin: 0; padding: 0;">
+                    <img src="https://res.cloudinary.com/dltfdjwzs/image/upload/v1780009089/01235ad8-2454-4a46-98cd-163de62e7fa0.png" 
+                         style="width: 100%; display: block; margin: 0; padding: 0;">
+                </div>
+                <div style="padding: 10px 10px 30px 30px;">
+                    <br>
+                    <p style="text-align: left; font-weight: bold;">Hello, {username}!</p>
+                    <div style="padding-left: 15px;">
+                        <p style="font-size: 15px;">Welcome to Stockton Esports! We're glad to have you.</p>
+                        <p style="font-size: 15px;">Please click the button below to verify your Stockton Esports Management Tool account:</p>
+                        <a href="{verify_url}" 
+                           style="display: inline-block; padding: 12px 24px; background-color: #6a0dad; color: #ffffff; 
+                                  text-decoration: none; border-radius: 5px; font-weight: bold; font-size: 15px;">
+                            Verify My Account
+                        </a>
+                        <br><br>
+                        <p>This link will expire after 24 hours.</p>
+                        <p>If you did not create this account, please ignore this email.</p>
+                    </div>
+                    <br>
+                    <p style="text-align: left;">- EsMT Team</p>
+                </div>
+                {get_email_footer()}
+            </div>
+        </div>
+    '''
     mail.send(msg)
+
+# Verifies token for email verification
+def register_verification_routes(app, mysql):
+    @app.route('/verify/<token>')
+    def verify_email(token: str):
+        """
+        Process email verification when user clicks verification link.
+        Verifies the token is valid and not expired, then marks the user's
+        account as verified in the database.
+
+        Returns:
+            Redirect to login page on success, or registration page on failure
+        """
+        cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+        try:
+            # Look up token and check expiry
+            cursor.execute(
+                'SELECT * FROM verified_users WHERE verification_token = %s AND token_expiry > NOW()',
+                (token,)
+            )
+            user = cursor.fetchone()
+
+            if user:
+                # Mark user as verified and clear token
+                cursor.execute(
+                    '''UPDATE verified_users 
+                       SET is_verified = TRUE, verification_token = NULL, token_expiry = NULL 
+                       WHERE userid = %s''',
+                    (user['userid'],)
+                )
+                mysql.connection.commit()
+                flash('Email is successfully verified, welcome to Stockton Esports! You can now log in.', 'success')
+                return redirect(url_for('login'))
+            else:
+                flash('ERROR: Verification link is invalid/expired.', 'error')
+                return redirect(url_for('register'))
+        finally:
+            cursor.close()
+
+
+# =========================================
+# UNIVERSAL EMAIL FOOTER
+# =========================================
+def get_email_footer() -> str:
+    return f'''
+        <div style="background-color: #1a1a2e; padding: 15px 20px 8px 20px; text-align: center; font-size: 12px; color: #aaaaaa;">
+            <a href="https://discord.gg/AGkHpVYfGh" 
+               style="color: #5865F2; font-weight: bold; text-decoration: none; 
+                      border: 2px solid #5865F2; padding: 4px 10px; border-radius: 4px;">
+                Join us on Discord!
+            </a>
+            <hr style="border: 1px solid #2a2a4a; margin: 14px 0 8px 0;">
+            <p style="margin: 0;">© {datetime.now().year} Stockton Esports Management Tool. All rights reserved.</p>
+        </div>
+    '''
+
 
 # =========================================
 # ARTIFICIAL TESTING TRIGGERS
@@ -47,6 +123,5 @@ def register_test_routes(app):
 
         @app.route('/test-email/verify')
         def test_verification_email():
-            send_verify_email("test@go.stockton.edu", "test-token")
+            send_verify_email("test@go.stockton.edu", "test-token", "user")
             return "Verification email sent - check localhost:8025"
-

--- a/EsportsManagementTool/EsportsManagementTool/email_manager.py
+++ b/EsportsManagementTool/EsportsManagementTool/email_manager.py
@@ -1,0 +1,52 @@
+"""
+Esports Management Tool Automatic Email Handler/Email Testing
+This file verifies and sends all automatic emails & can test emails via Mailpit.
+"""
+
+from EsportsManagementTool import app, mail
+from flask import url_for
+from flask_mail import Message
+
+
+# =========================================
+# EMAIL SENDING FUNCTIONS
+# =========================================
+
+# Account Verification Email
+def send_verify_email(email: str, token: str) -> None:
+    """
+    Send verification email to newly registered users.
+    Constructs and sends an email containing a verification link that
+    expires after 24 hours.
+    """
+    verify_url = url_for('verify_email', token=token, _external=True)
+    msg = Message('Verify Your Stockton University Email Account', recipients=[email])
+    msg.body = f'''Hello,
+Please click the link below to verify your Stockton Esports Management Tool account:
+
+{verify_url}
+
+This link will expire after 24 hours.
+
+If you did not create this account, please ignore this email.
+
+- EsMT Team.
+'''
+    mail.send(msg)
+
+# =========================================
+# ARTIFICIAL TESTING TRIGGERS
+# =========================================
+# 1. Make sure MAILING_MODE (within init) is set to "testing".
+# 2. Run Mailpit within your local terminal.
+# 3. Type http://localhost:5000/{route} into your browser to send the email.
+# 4. Open http://localhost:8025 to view the Mailpit inbox.
+
+def register_test_routes(app):
+    if app.config.get('MAIL_SERVER') == 'localhost':
+
+        @app.route('/test-email/verify')
+        def test_verification_email():
+            send_verify_email("test@go.stockton.edu", "test-token")
+            return "Verification email sent - check localhost:8025"
+

--- a/EsportsManagementTool/EsportsManagementTool/email_manager.py
+++ b/EsportsManagementTool/EsportsManagementTool/email_manager.py
@@ -24,13 +24,13 @@ def send_verify_email(email: str, token: str, username: str) -> None:
     verify_url = url_for('verify_email', token=token, _external=True)
     msg = Message('Verify Your Stockton University Email Account', recipients=[email])
     msg.html = f'''
-        <div style="background-color: #f4f4f4; width: 100%; margin: 0; padding: 10px 0;">
+        <div style="background-color: #f4f4f4; width: 100%; margin: 0; padding: 10px 0; font-family: 'Inter', sans-serif;">
             <div style="background-color: #ffffff; max-width: 600px; margin: 0 auto;">
                 <div style="margin: 0; padding: 0;">
                     <img src="https://res.cloudinary.com/dltfdjwzs/image/upload/v1780009089/01235ad8-2454-4a46-98cd-163de62e7fa0.png" 
                          style="width: 100%; display: block; margin: 0; padding: 0;">
                 </div>
-                <div style="padding: 10px 10px 30px 30px;">
+                <div style="padding: 8px 10px 20px 30px;">
                     <br>
                     <p style="text-align: left; font-weight: bold;">Hello, {username}!</p>
                     <div style="padding-left: 15px;">
@@ -42,10 +42,9 @@ def send_verify_email(email: str, token: str, username: str) -> None:
                             Verify My Account
                         </a>
                         <br><br>
-                        <p>This link will expire after 24 hours.</p>
-                        <p>If you did not create this account, please ignore this email.</p>
+                        <p style="font-size: 15px;">This link will expire after 24 hours.</p>
+                        <p style="font-size: 15px;">If you did not create this account, please ignore this email.</p>
                     </div>
-                    <br>
                     <p style="text-align: left;">- EsMT Team</p>
                 </div>
                 {get_email_footer()}
@@ -98,14 +97,16 @@ def register_verification_routes(app, mysql):
 # =========================================
 def get_email_footer() -> str:
     return f'''
-        <div style="background-color: #1a1a2e; padding: 15px 20px 8px 20px; text-align: center; font-size: 12px; color: #aaaaaa;">
+        <div style="background-color: #1a1a2e; padding: 15px 20px 8px 20px; text-align: center; font-size: 12px;
+        color: #aaaaaa; font-family: 'Inter', sans-serif;">
             <a href="https://discord.gg/AGkHpVYfGh" 
                style="color: #5865F2; font-weight: bold; text-decoration: none; 
                       border: 2px solid #5865F2; padding: 4px 10px; border-radius: 4px;">
                 Join us on Discord!
             </a>
-            <hr style="border: 1px solid #2a2a4a; margin: 14px 0 8px 0;">
-            <p style="margin: 0;">© {datetime.now().year} Stockton Esports Management Tool. All rights reserved.</p>
+            <br><br>
+            <p style="margin: 0 0 8px 0;">Have a question? Contact <strong>seiberlh@go.stockton.edu</strong> for assistance!</p>
+            <p style="margin: 0;">©{datetime.now().year} Stockton Esports Management Tool. All rights reserved.</p>
         </div>
     '''
 
@@ -123,5 +124,5 @@ def register_test_routes(app):
 
         @app.route('/test-email/verify')
         def test_verification_email():
-            send_verify_email("test@go.stockton.edu", "test-token", "user")
+            send_verify_email("test@go.stockton.edu", "test-token", "test username")
             return "Verification email sent - check localhost:8025"


### PR DESCRIPTION
### KAN-40: Refactored `init.py` and added `email_manager.py`:

- `email_manager.py` added to house all emails, email helper functions, and artificial emailing triggers (for testing).
- Regular email triggers remain within their old spots.
- Local testing mode for emails within `email_manager.py` via Mailpit.
- Account verification email & logic moved to `email_manager.py`.
- Account verification email restructured.
- A universal footer implemented to append to the bottom of all emails.
- `MALIING_MODE` added to `init.py` to differentiate email routing.

**Important**: For future use, please keep `MAILING_MODE` set to "production" when finalizing future PRs.