### PR TITLE
Complete Email Overhaul

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/__init__.py
+++ b/EsportsManagementTool/EsportsManagementTool/__init__.py
@@ -374,7 +374,7 @@ def login():
                         mysql.connection.commit()
 
                         try:
-                            send_verify_email(account['email'], verification_token, username)
+                            send_verify_email(account['email'], verification_token, account['firstname'])
                             msg = 'Email sent.'
                         except Exception as e:
                             msg = f'Email failed to send. Error: {str(e)}'
@@ -596,7 +596,7 @@ def register():
                 mysql.connection.commit()
 
                 # Send verification email
-                send_verify_email(email, verification_token, username)
+                send_verify_email(email, verification_token, firstname)
                 msg = ('You have successfully created an account! Please check your email for verification! '
                        'If the email does not appear in your inbox, please check your spam!')
         finally:
@@ -614,7 +614,7 @@ def register():
 import EsportsManagementTool.universal_helpers
 import EsportsManagementTool.exampleModule
 import EsportsManagementTool.UpdateProfile
-import EsportsManagementTool.EventNotificationManager
+import EsportsManagementTool.event_notifications
 import EsportsManagementTool.suspensions
 import EsportsManagementTool.events
 import EsportsManagementTool.dashboard
@@ -654,7 +654,7 @@ tournament_results.register_tournament_results_routes(app, mysql, login_required
 
 # Initialize tournament notification scheduler
 from EsportsManagementTool import tournament_notification_scheduler
-tournament_notification_scheduler.initialize_tournament_scheduler(app, mysql, mail)
+tournament_notification_scheduler.initialize_tournament_scheduler(app, mysql)
 
 # Register verification email routes
 from EsportsManagementTool import email_manager

--- a/EsportsManagementTool/EsportsManagementTool/email_manager.py
+++ b/EsportsManagementTool/EsportsManagementTool/email_manager.py
@@ -15,7 +15,7 @@ import MySQLdb.cursors
 # =========================================
 
 # Account Verification Email
-def send_verify_email(email: str, token: str, username: str) -> None:
+def send_verify_email(email: str, token: str, user_firstname: str) -> None:
     """
     Send verification email to newly registered users.
     Constructs and sends an email containing a verification link that
@@ -32,7 +32,7 @@ def send_verify_email(email: str, token: str, username: str) -> None:
                 </div>
                 <div style="padding: 8px 10px 20px 30px;">
                     <br>
-                    <p style="text-align: left; font-weight: bold;">Hello, {username}!</p>
+                    <p style="text-align: left; font-weight: bold;">Hello, {user_firstname}!</p>
                     <div style="padding-left: 15px;">
                         <p style="font-size: 15px;">Welcome to Stockton Esports! We're glad to have you.</p>
                         <p style="font-size: 15px;">Please click the button below to verify your Stockton Esports Management Tool account:</p>
@@ -91,6 +91,97 @@ def register_verification_routes(app, mysql):
         finally:
             cursor.close()
 
+# Event Notification Email
+def send_event_notification(user_email, user_firstname, event_type, start_time, event_details):
+    """Send email notification to user about upcoming event."""
+    try:
+        msg = Message(f"Reminder: Upcoming {event_type}", recipients=[user_email])
+        msg.html = f'''
+                <div style="background-color: #f4f4f4; width: 100%; margin: 0; padding: 10px 0; font-family: 'Inter', sans-serif;">
+                    <div style="background-color: #ffffff; max-width: 600px; margin: 0 auto;">
+                        <div style="margin: 0; padding: 0;">
+                            <img src="https://res.cloudinary.com/dltfdjwzs/image/upload/v1780009089/01235ad8-2454-4a46-98cd-163de62e7fa0.png"
+                                 style="width: 100%; display: block; margin: 0; padding: 0;">
+                        </div>
+                        <div style="padding: 8px 10px 20px 30px;">
+                            <br>
+                            <p style="text-align: left; font-weight: bold;">Hello, {user_firstname}!</p>
+                            <div style="padding-left: 15px;">
+                                <p style="font-size: 15px;">This is a reminder about your upcoming {event_type.lower()}:</p>
+                                <p style="font-size: 15px;">
+                                    <strong>Event:</strong> {event_details['EventName']}<br>
+                                    <strong>Date:</strong> {event_details['date'].strftime('%B %d, %Y')}<br>
+                                    <strong>Time:</strong> {start_time.strftime('%I:%M %p')}<br>
+                                    <strong>Location:</strong> {event_details['location']}
+                                </p>
+                                <p style="font-size: 15px;"><strong>Event Details:</strong><br>
+                                    {event_details.get('description', 'No additional details')}
+                                </p>
+                                <p style="font-size: 15px;">We look forward to seeing you there!</p>
+                            </div>
+                            <p style="text-align: left;">- EsMT Team</p>
+                        </div>
+                        {get_email_footer()}
+                    </div>
+                </div>
+            '''
+        mail.send(msg)
+
+        return True
+    except Exception as e:
+        print(f"Error sending email to {user_email}: {e}")
+        return False
+
+# GM Reminder Email
+def send_reminder_email(user_email, user_firstname, season_name, game_title, pending_count, days_until_end):
+    """Send GMs reminders to update their tournament results."""
+    try:
+        urgency = "URGENT " if days_until_end <= 3 else ""
+
+        subject = f"{urgency}Action Required: Record Tournament Results for {game_title}"
+
+        msg = Message(subject, recipients=[user_email])
+        msg.html = f'''
+                <div style="background-color: #f4f4f4; width: 100%; margin: 0; padding: 10px 0; font-family: 'Inter', sans-serif;">
+                    <div style="background-color: #ffffff; max-width: 600px; margin: 0 auto;">
+                        <div style="margin: 0; padding: 0;">
+                            <img src="https://res.cloudinary.com/dltfdjwzs/image/upload/v1780009089/01235ad8-2454-4a46-98cd-163de62e7fa0.png"
+                                 style="width: 100%; display: block; margin: 0; padding: 0;">
+                        </div>
+                        <div style="padding: 8px 10px 20px 30px;">
+                            <br>
+                            <p style="text-align: left; font-weight: bold;">Hello, {user_firstname}!</p>
+                            <div style="padding-left: 15px;">
+                                <p style="font-size: 15px;">This is a reminder to record tournament results for <strong>{game_title}</strong> in the <strong>{season_name}</strong> season.</p>
+                                <p style="font-size: 15px;">
+                                    <strong>Season End:</strong> {days_until_end} day(s) remaining<br>
+                                    <strong>Pending Results:</strong> {pending_count} team(s) need tournament placement recorded.
+                                </p>
+                                <p style="font-size: 15px;">Please log into the Stockton Esports Management Tool and click the <strong>"Record Tournament Results"</strong> button in your dashboard to get started.</p>
+                                <p style="font-size: 15px;"><strong>Tournament placement options:</strong><br>
+                                    Winner (1st place)<br>
+                                    Finals (2nd place)<br>
+                                    Semifinals (3rd–4th place)<br>
+                                    Quarterfinals (5th–8th place)<br>
+                                    Playoffs (made playoffs)<br>
+                                    Regular Season (did not make playoffs)
+                                </p>
+                                <p style="font-size: 15px;">Thank you for your prompt attention to this matter.</p>
+                            </div>
+                            <p style="text-align: left;">- EsMT Team</p>
+                        </div>
+                        {get_email_footer()}
+                    </div>
+                </div>
+            '''
+
+        mail.send(msg)
+        return True
+
+    except Exception as e:
+        print(f"Error sending reminder email to {user_email}: {str(e)}")
+        return False
+
 
 # =========================================
 # UNIVERSAL EMAIL FOOTER
@@ -116,7 +207,7 @@ def get_email_footer() -> str:
 # =========================================
 # 1. Make sure MAILING_MODE (within init) is set to "testing".
 # 2. Run Mailpit within your local terminal.
-# 3. Type http://localhost:5000/{route} into your browser to send the email.
+# 3. Type http://localhost:5000{route} into your browser to send the email.
 # 4. Open http://localhost:8025 to view the Mailpit inbox.
 
 def register_test_routes(app):
@@ -124,5 +215,30 @@ def register_test_routes(app):
 
         @app.route('/test-email/verify')
         def test_verification_email():
-            send_verify_email("test@go.stockton.edu", "test-token", "test username")
+            send_verify_email("test@go.stockton.edu", "test-token", "testfirstname")
             return "Verification email sent - check localhost:8025"
+
+        @app.route('/test-email/event-notification')
+        def test_event_notification_email():
+            from datetime import date, time
+            send_event_notification("test@go.stockton.edu","testfirstname","Match", datetime.now(),
+                {
+                    'EventName': 'Test Match',
+                    'date': date.today(),
+                    'location': 'Esports Lab',
+                    'description': 'description description description description description description description description'
+                }
+            )
+            return "Event notification email sent - check localhost:8025"
+
+        @app.route('/test-email/gm-reminder')
+        def test_reminder_email():
+            send_reminder_email(
+                "test@go.stockton.edu",
+                "testfirstname",
+                "Fall 2026",
+                "Fortnite Duos",
+                1,
+                2
+            )
+            return "GM reminder email sent - check localhost:8025"

--- a/EsportsManagementTool/EsportsManagementTool/event_notifications.py
+++ b/EsportsManagementTool/EsportsManagementTool/event_notifications.py
@@ -1,23 +1,16 @@
-from EsportsManagementTool import app
-from flask import Flask, render_template, request, redirect, url_for, session, flash, jsonify
+from flask import request, redirect, url_for, session, flash, jsonify
 from flask_mysqldb import MySQL
-from flask_mail import Mail, Message
-import MySQLdb.cursors
-import bcrypt
-from dotenv import load_dotenv
 from datetime import datetime, timedelta
 from apscheduler.schedulers.background import BackgroundScheduler
+from EsportsManagementTool import app, EST, email_manager
 import atexit
-from EsportsManagementTool import app, EST
+import MySQLdb.cursors
 import os
 
 mysql = MySQL()
-mail = Mail()
-
-"""DISCLAIMER: THIS CODE WAS GENERATED USING CLAUDE AI AND CHATGPT"""
 
 
-# UC-13: ChooseEventNotice - User Notification Preferences (Enhanced with Event Type Filtering)
+# User Notification Preferences (Enhanced with Event Type Filtering)
 @app.route('/eventnotificationsettings', methods=['GET', 'POST'])
 def notification_settings():
     """Allow users to configure their event notification preferences including event types"""
@@ -108,40 +101,6 @@ def notification_settings():
     # GET request - redirect to dashboard (no standalone page anymore)
     return redirect(url_for('dashboard'))
 
-# UC-14: SendEventNotice - Automated Email Notifications
-def send_event_notification(user_email, user_name, event_type, event_details):
-    """Send email notification to user about upcoming event"""
-    try:
-        subject = f"Reminder: Upcoming {event_type}"
-
-        body = f"""
-        Hello {user_name},
-
-        This is a reminder about your upcoming {event_type.lower()}:
-
-        Event: {event_details['EventName']}
-        Date: {event_details['date'].strftime('%B %d, %Y')}
-        Time: {event_details['StartTime'].strftime('%I:%M %p')}
-        Location: {event_details['location']}
-
-        Event Details:
-        {event_details.get('description', 'No additional details')}
-
-        We look forward to seeing you there!
-
-        Best regards,
-        Esports Management Tool
-        """
-
-        msg = Message(subject=subject, recipients=[user_email], body=body)
-        mail.send(msg)
-
-        return True
-    except Exception as e:
-        print(f"Error sending email to {user_email}: {e}")
-        return False
-
-
 def check_and_send_notifications():
     """
     Background task to check for upcoming events and send notifications
@@ -229,19 +188,19 @@ def check_and_send_notifications():
 
             visibility_check = build_visibility_check(user_teams, user_games, user['user_id'])
 
-            # 1. General Events - check notification preference and visibility
+            # General Events - check notification preference and visibility
             if user['notify_events']:
                 event_conditions.append(f"(ge.EventType = 'Event' AND ({visibility_check}))")
 
-            # 2. Matches - check notification preference and visibility
+            # Matches - check notification preference and visibility
             if user['notify_matches']:
                 event_conditions.append(f"(ge.EventType = 'Match' AND ({visibility_check}))")
 
-            # 3. Practices - check notification preference and visibility
+            # Practices - check notification preference and visibility
             if user['notify_practices']:
                 event_conditions.append(f"(ge.EventType = 'Practice' AND ({visibility_check}))")
 
-            # 4. Tournaments - for all games user is associated with
+            # Tournaments - for all games user is associated with
             if user['notify_tournaments'] and user_games:
                 game_ids = ','.join([str(gid) for gid in user_games])
                 # Tournaments should reach game community and players
@@ -251,11 +210,11 @@ def check_and_send_notifications():
                     ))
                 """)
 
-            # 5. Misc - check notification preference and visibility
+            # Misc - check notification preference and visibility
             if user['notify_misc']:
                 event_conditions.append(f"(ge.EventType = 'Misc' AND ({visibility_check}))")
 
-            # 6. Manual Subscriptions - ALWAYS include events user manually subscribed to
+            # Subscriptions - ALWAYS include events user manually subscribed to
             # Manual subscriptions override category preferences but still respect visibility
             event_conditions.append(f"""
                 (ge.EventID IN (
@@ -318,10 +277,11 @@ def check_and_send_notifications():
                 # Capitalize event type for display
                 event_label = event['event_type'].capitalize() if event['event_type'] else 'Event'
 
-                if send_event_notification(
+                if email_manager.send_event_notification(
                         user['email'],
                         user['firstname'],
                         event_label,
+                        event['StartTime'],
                         event
                 ):
                     # Log sent notification
@@ -340,7 +300,7 @@ def check_and_send_notifications():
         cursor.close()
 
 # ========================================================================
-# Initialize scheduler for background notifications (UC-14)
+# Initialize scheduler for background notifications
 # ========================================================================
 def scheduled_check_wrapper():
     """Wrapper ensures the scheduler runs safely within the Flask app context"""
@@ -354,7 +314,6 @@ def scheduled_check_wrapper():
             import traceback
             traceback.print_exc()
             print(f"[{datetime.now()}] Error in notification scheduler: {str(e)}")
-
 
 # Only start scheduler in the main process (not the reloader)
 if os.environ.get('WERKZEUG_RUN_MAIN') == 'true' or not app.debug:
@@ -375,4 +334,3 @@ if os.environ.get('WERKZEUG_RUN_MAIN') == 'true' or not app.debug:
 
     # Ensure clean shutdown on app exit
     atexit.register(lambda: scheduler.shutdown(wait=False))
-"""DISCLAIMER: THIS CODE WAS GENERATED USING CLAUDE AI AND CHATGPT"""

--- a/EsportsManagementTool/EsportsManagementTool/tournament_notification_scheduler.py
+++ b/EsportsManagementTool/EsportsManagementTool/tournament_notification_scheduler.py
@@ -2,14 +2,14 @@
 Tournament Results Notification Scheduler
 Sends email reminders to Game Managers to record tournament results
 """
-from datetime import datetime, timedelta
+from datetime import datetime
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
-from flask_mail import Message
+from EsportsManagementTool import email_manager
 import MySQLdb.cursors
 
 
-def initialize_tournament_scheduler(app, mysql, mail):
+def initialize_tournament_scheduler(app, mysql):
     """
     Initialize the tournament notification scheduler
     Runs daily to check and send reminders
@@ -18,7 +18,7 @@ def initialize_tournament_scheduler(app, mysql, mail):
     
     # Run daily at 9:00 AM
     scheduler.add_job(
-        func=lambda: check_and_send_reminders(app, mysql, mail),
+        func=lambda: check_and_send_reminders(app, mysql),
         trigger=CronTrigger(hour=9, minute=0),
         id='tournament_reminders',
         name='Send tournament result reminders to GMs',
@@ -32,8 +32,7 @@ def initialize_tournament_scheduler(app, mysql, mail):
     import atexit
     atexit.register(lambda: scheduler.shutdown())
 
-
-def check_and_send_reminders(app, mysql, mail):
+def check_and_send_reminders(app, mysql):
     """
     Check for seasons nearing end and send reminders to GMs
     
@@ -75,15 +74,14 @@ def check_and_send_reminders(app, mysql, mail):
                     should_send = True
                 
                 if should_send:
-                    send_season_reminders(mysql, mail, season_id, season_name, end_date, days_until_end)
+                    send_season_reminders(mysql, season_id, season_name, end_date, days_until_end)
                     
         except Exception as e:
             print(f"Error in tournament reminder scheduler: {str(e)}")
         finally:
             cursor.close()
 
-
-def send_season_reminders(mysql, mail, season_id, season_name, end_date, days_until_end):
+def send_season_reminders(mysql, season_id, season_name, end_date, days_until_end):
     """
     Send reminders to all GMs who haven't completed their tournament results
     """
@@ -96,7 +94,6 @@ def send_season_reminders(mysql, mail, season_id, season_name, end_date, days_un
                 u.id as gm_id,
                 u.email,
                 u.firstname,
-                u.lastname,
                 g.GameID,
                 g.GameTitle
             FROM users u
@@ -113,7 +110,7 @@ def send_season_reminders(mysql, mail, season_id, season_name, end_date, days_un
                 AND trn.game_id = g.GameID
                 AND trn.is_completed = TRUE
             )
-            GROUP BY u.id, u.email, u.firstname, u.lastname, g.GameID, g.GameTitle
+            GROUP BY u.id, u.email, u.firstname, g.GameID, g.GameTitle
         """, (season_id, season_id))
         
         gms = cursor.fetchall()
@@ -149,10 +146,14 @@ def send_season_reminders(mysql, mail, season_id, season_name, end_date, days_un
                 """, (gm_id, season_id, game_id))
                 
                 notification_record = cursor.fetchone()
-                
+
+                if notification_record:
+                    last_sent = notification_record['last_reminder_sent']
+                    if last_sent and (datetime.now() - last_sent).days < 1:
+                        continue  # Already sent today, skip
+
                 # Send email
-                send_reminder_email(
-                    mail, 
+                email_manager.send_reminder_email(
                     gm['email'], 
                     gm['firstname'],
                     season_name,
@@ -183,61 +184,3 @@ def send_season_reminders(mysql, mail, season_id, season_name, end_date, days_un
         print(f"Error sending season reminders: {str(e)}")
     finally:
         cursor.close()
-
-
-def send_reminder_email(mail, email, firstname, season_name, game_title, pending_count, days_until_end):
-    """
-    Send reminder email to GM
-    """
-    try:
-        urgency = "URGENT: " if days_until_end <= 3 else ""
-        
-        subject = f"{urgency}Action Required: Record Tournament Results for {game_title}"
-        
-        # Create email body
-        body = f"""Hello {firstname},
-
-This is a reminder to record tournament results for {game_title} in the {season_name} season.
-
-Season End Date: {days_until_end} day(s) remaining
-Pending Results: {pending_count} team(s) need tournament placement recorded
-
-Please log into the Stockton Esports Management Tool to record your results:
-(Our domain link)
-
-Click the "Record Tournament Results" button in your dashboard to get started.
-
-Tournament placement options:
-- Winner (1st place)
-- Finals (2nd place)  
-- Semifinals (3rd-4th place)
-- Quarterfinals (5th-8th place)
-- Playoffs (made playoffs)
-- Regular Season (did not make playoffs)
-
-Thank you for your prompt attention to this matter.
-
-Best regards,
-Stockton Esports Management Team
-"""
-        
-        msg = Message(
-            subject,
-            recipients=[email],
-            body=body
-        )
-        
-        mail.send(msg)
-        return True
-        
-    except Exception as e:
-        print(f"Error sending reminder email to {email}: {str(e)}")
-        return False
-
-
-def manual_trigger_reminders(app, mysql, mail):
-    """
-    Manually trigger reminder check (useful for testing)
-    """
-    check_and_send_reminders(app, mysql, mail)
-


### PR DESCRIPTION
### KAN-40 Improve Visuals on Emails
#### This PR is a "part 2" from the last email rework PR.
- Event notification email and GM reminder email moved to `email_manager.py`
- Both emails mentioned are formatted the exact same way as the account verification email. (header, footer, style)
- Emails now begin with "Hello, {firstname}" as opposed to username.
- Artificial Test Triggers added for new emails.

### Please reference the thread "All New Email Visuals (filled with test parameters)" within #major-task-threads for visuals on all emails.
Note: the forgot password email & functionality will have it's own PR at a later date.