### PR TITLE
KAN-83 Adjust GM Record Banner to Appear Less Often

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/static/teamstats.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teamstats.js
@@ -148,7 +148,7 @@ async function loadStatsTab(teamId, gameId, leagueId = null) {
  * Render the complete stats content with league filter dropdown
  * Displays summary cards and match history
  */
-function renderStatsContent() {
+async function renderStatsContent() {
     const statsPanel = document.getElementById('statsTabContent');
 
     // Calculate statistics
@@ -160,6 +160,16 @@ function renderStatsContent() {
     if (totalMatches > 0) {
         const rawPercentage = (wins / totalMatches) * 100;
         winPercentage = (rawPercentage % 1 === 0) ? rawPercentage.toFixed(0) : rawPercentage.toFixed(1);
+    }
+
+    // Check if current user can record results for this team
+    let canRecordResults = false;
+    try {
+        const permResponse = await fetch(`/api/teams/${currentStatsTeamId}/can-record`);
+        const permData = await permResponse.json();
+        canRecordResults = permData.success && permData.can_record;
+    } catch (e) {
+        console.error('Error checking record permissions:', e);
     }
 
     // Build league filter dropdown
@@ -181,6 +191,17 @@ function renderStatsContent() {
             </div>
         `;
     }
+
+    // Build tournament results button for GMs and admins
+    const tournamentBtnHTML = canRecordResults ? `
+        <button class="btn btn-primary btn-sm" 
+                onclick="openRecordResultsModal()" 
+                title="Record team results for your teams"
+                style="display: flex; align-items: center; gap: 0.4rem;">
+            <i class="fas fa-trophy"></i>
+            Record Team Results
+        </button>
+    ` : '';
 
     // Build stats UI
     statsPanel.innerHTML = `
@@ -243,6 +264,7 @@ function renderStatsContent() {
                         Match History
                         ${currentLeagueFilter ? `<span style="color: var(--stockton-blue); font-size: 0.875rem; font-weight: normal; margin-left: 0.5rem;">(${availableLeagues.find(l => l.id === currentLeagueFilter)?.name})</span>` : ''}
                     </h3>
+                    ${tournamentBtnHTML}
                 </div>
 
                 ${renderMatchHistory()}

--- a/EsportsManagementTool/EsportsManagementTool/static/tournament-results.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/tournament-results.js
@@ -22,9 +22,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
 /**
  * Check if GM has pending tournament results
- * Shows banner if within 30 days of season end
+ * Shows banner if within 7 days of season end, once per day per browser session
  */
 function checkPendingResults() {
+    // Only show banner once per day — check localStorage for today's date
+    const today = new Date().toISOString().split('T')[0];
+    const lastShown = localStorage.getItem('tournamentBannerDate');
+    if (lastShown === today) {
+        return; // Already shown today, skip API call entirely
+    }
+
     fetch('/api/tournament-results/check-pending')
         .then(response => response.json())
         .then(data => {
@@ -34,6 +41,9 @@ function checkPendingResults() {
                     data.days_until_end,
                     data.season_name
                 );
+                // Record that we showed the banner today so it won't reappear until tomorrow
+                const today = new Date().toISOString().split('T')[0];
+                localStorage.setItem('tournamentBannerDate', today);
             }
         })
         .catch(error => {

--- a/EsportsManagementTool/EsportsManagementTool/team_stats.py
+++ b/EsportsManagementTool/EsportsManagementTool/team_stats.py
@@ -448,6 +448,47 @@ def register_team_stats_routes(app, mysql, login_required, roles_required):
             }), 500
 
     # ============================================
+    # CHECK RECORD PERMISSIONS
+    # ============================================
+    @app.route('/api/teams/<team_id>/can-record', methods=['GET'])
+    @login_required
+    def can_record_results(team_id):
+        """
+        Check if current user can record match/tournament results for a team.
+        Returns true if user is the GM for this team's game OR is an admin.
+        Used to conditionally show the Record Results button on the team stats page.
+        """
+        user_id = session.get('id')
+        cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+
+        try:
+            # Check admin status
+            permissions = get_user_permissions(user_id)
+            if permissions.get('is_admin'):
+                return jsonify({'success': True, 'can_record': True}), 200
+
+            # Check if user is GM for this team's game
+            cursor.execute("""
+                SELECT g.gm_id
+                FROM teams t
+                JOIN games g ON t.gameID = g.GameID
+                WHERE t.TeamID = %s
+            """, (team_id,))
+
+            result = cursor.fetchone()
+            if not result:
+                return jsonify({'success': False, 'can_record': False}), 404
+
+            can_record = result['gm_id'] == user_id
+            return jsonify({'success': True, 'can_record': can_record}), 200
+
+        except Exception as e:
+            print(f"Error checking record permissions: {str(e)}")
+            return jsonify({'success': False, 'can_record': False}), 500
+        finally:
+            cursor.close()
+
+    # ============================================
     # DELETE MATCH RESULT
     # ============================================
     @app.route('/api/teams/delete-match-result/<int:result_id>', methods=['DELETE'])

--- a/EsportsManagementTool/EsportsManagementTool/tournament_notification_scheduler.py
+++ b/EsportsManagementTool/EsportsManagementTool/tournament_notification_scheduler.py
@@ -38,20 +38,20 @@ def check_and_send_reminders(app, mysql, mail):
     Check for seasons nearing end and send reminders to GMs
     
     Reminder schedule:
-    - Weekly reminders from 30 days to 4 days before end
+    - One reminder at exactly 7 days before end
     - Daily reminders for last 3 days
     """
     with app.app_context():
         cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
         
         try:
-            # Get active seasons within 30 days of ending
+            # Get active seasons within 7 days of ending
             cursor.execute("""
                 SELECT season_id, season_name, end_date
                 FROM seasons
                 WHERE is_active = 1
                 AND end_date >= CURDATE()
-                AND end_date <= DATE_ADD(CURDATE(), INTERVAL 30 DAY)
+                AND end_date <= DATE_ADD(CURDATE(), INTERVAL 7 DAY)
             """)
             
             seasons = cursor.fetchall()
@@ -64,15 +64,10 @@ def check_and_send_reminders(app, mysql, mail):
                 
                 print(f"Checking reminders for {season_name} - {days_until_end} days until end")
                 
-                # Determine if we should send reminders today
-                should_send = False
-                
-                if days_until_end <= 3:
-                    # Last 3 days: send daily
-                    should_send = True
-                elif days_until_end <= 30 and days_until_end % 7 == 0:
-                    # 4-30 days: send weekly (every 7 days)
-                    should_send = True
+                # Determine if we should send reminders today:
+                # - Exactly 7 days out: one early warning
+                # - Last 3 days: daily reminders
+                should_send = days_until_end <= 3 or days_until_end == 7
                 
                 if should_send:
                     send_season_reminders(mysql, mail, season_id, season_name, end_date, days_until_end)

--- a/EsportsManagementTool/EsportsManagementTool/tournament_results.py
+++ b/EsportsManagementTool/EsportsManagementTool/tournament_results.py
@@ -236,7 +236,7 @@ def register_tournament_results_routes(app, mysql, login_required, roles_require
             days_until_end = (end_date - datetime.now().date()).days
             
             # Only show notification if within 30 days of season end
-            if days_until_end > 30 or days_until_end < 0:
+            if days_until_end > 7 or days_until_end < 0:
                 return jsonify({
                     'success': True,
                     'has_pending': False,


### PR DESCRIPTION
- Limited the recording season results banner to 7 days before the season ends opposed to a month.
- An email notification will be sent out 7 days before a season end and every day for the last 3 days
- Recording results banner now only appears once a day.
- To account for the banner disappearing, Game Managers now have the option to record results from the teamstats page for their specific game. Admins also have access to this button for every game, we can discuss this in the meeting. 