### PR TITLE
Change 'Regular Season' label to 'Did Not Qualify'

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/email_manager.py
+++ b/EsportsManagementTool/EsportsManagementTool/email_manager.py
@@ -164,7 +164,7 @@ def send_reminder_email(user_email, user_firstname, season_name, game_title, pen
                                     Semifinals (3rd–4th place)<br>
                                     Quarterfinals (5th–8th place)<br>
                                     Playoffs (made playoffs)<br>
-                                    Regular Season (did not make playoffs)
+                                    Did Not Qualify (DNQ)
                                 </p>
                                 <p style="font-size: 15px;">Thank you for your prompt attention to this matter.</p>
                             </div>

--- a/EsportsManagementTool/EsportsManagementTool/static/admin-statistics.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/admin-statistics.js
@@ -199,7 +199,7 @@ function exportToExcel() {
     csvContent += `Semifinals,${window.statisticsData.tournament_placements.semifinals}\n`;
     csvContent += `Quarterfinals,${window.statisticsData.tournament_placements.quarterfinals}\n`;
     csvContent += `Playoffs,${window.statisticsData.tournament_placements.playoffs}\n`;
-    csvContent += `Regular Season,${window.statisticsData.tournament_placements.regular_season}\n`;
+    csvContent += `Did Not Qualify,${window.statisticsData.tournament_placements.regular_season}\n`;
     csvContent += `In Progress,${window.statisticsData.tournament_placements.in_progress}\n`;
     csvContent += "\n";
     

--- a/EsportsManagementTool/EsportsManagementTool/static/teamstats.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teamstats.css
@@ -629,7 +629,7 @@
 }
 
 /* ============================================
-   MATCH TYPE BADGES (Playoffs / Regular Season)
+   MATCH TYPE BADGES (Playoffs / Did Not Qualify)
    ============================================ */
 
 .match-type-badge {

--- a/EsportsManagementTool/EsportsManagementTool/statistics.py
+++ b/EsportsManagementTool/EsportsManagementTool/statistics.py
@@ -524,7 +524,7 @@ class EsportsStatistics:
                 'Semifinals': 'semifinals',
                 'Quarterfinals': 'quarterfinals',
                 'Playoffs': 'playoffs',
-                'Regular Season': 'regular_season'
+                'Did Not Qualify': 'regular_season'
             }
             
             for row in placements_data:

--- a/EsportsManagementTool/EsportsManagementTool/templates/admin_statistics.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/admin_statistics.html
@@ -216,7 +216,7 @@
                             <i class="fas fa-calendar-alt"></i>
                         </div>
                         <div class="placement-value">{{ league.regular_season }}</div>
-                        <div class="placement-label">Regular Season</div>
+                        <div class="placement-label">Did Not Qualify</div>
                     </div>
 
                     <div class="placement-card">

--- a/EsportsManagementTool/EsportsManagementTool/tournament_notification_scheduler.py
+++ b/EsportsManagementTool/EsportsManagementTool/tournament_notification_scheduler.py
@@ -37,6 +37,7 @@ def check_and_send_reminders(app, mysql):
     Check for seasons nearing end and send reminders to GMs
     
     Reminder schedule:
+    - One reminder at exactly 21 days before end
     - One reminder at exactly 7 days before end
     - Daily reminders for last 3 days
     """
@@ -44,13 +45,13 @@ def check_and_send_reminders(app, mysql):
         cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
         
         try:
-            # Get active seasons within 7 days of ending
+            # Get active seasons within 21 days of ending
             cursor.execute("""
                 SELECT season_id, season_name, end_date
                 FROM seasons
                 WHERE is_active = 1
                 AND end_date >= CURDATE()
-                AND end_date <= DATE_ADD(CURDATE(), INTERVAL 7 DAY)
+                AND end_date <= DATE_ADD(CURDATE(), INTERVAL 21 DAY)
             """)
             
             seasons = cursor.fetchall()
@@ -63,10 +64,9 @@ def check_and_send_reminders(app, mysql):
                 
                 print(f"Checking reminders for {season_name} - {days_until_end} days until end")
                 
-                # Determine if we should send reminders today:
-                # - Exactly 7 days out: one early warning
-                # - Last 3 days: daily reminders
-                should_send = days_until_end <= 3 or days_until_end == 7
+                # Send reminders:
+                # - Exactly 21 days out, exactly 7 days out, last 3 days
+                should_send = days_until_end <= 3 or days_until_end == 7 or days_until_end == 21
                 
                 if should_send:
                     send_season_reminders(mysql, season_id, season_name, end_date, days_until_end)

--- a/EsportsManagementTool/EsportsManagementTool/tournament_results.py
+++ b/EsportsManagementTool/EsportsManagementTool/tournament_results.py
@@ -15,7 +15,7 @@ PLACEMENT_OPTIONS = [
     'Semifinals', 
     'Quarterfinals',
     'Playoffs',
-    'Regular Season'
+    'Did Not Qualify'
 ]
 
 
@@ -208,6 +208,9 @@ def register_tournament_results_routes(app, mysql, login_required, roles_require
         """
         Check if current GM has pending tournament results to record
         Returns count and whether to show notification banner
+
+        Banner display schedule:
+        - Shown continuously from 21 days before season end through the final day
         """
         gm_id = session.get('id')
         cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
@@ -235,8 +238,10 @@ def register_tournament_results_routes(app, mysql, login_required, roles_require
             # Calculate days until season end
             days_until_end = (end_date - datetime.now().date()).days
             
-            # Only show notification if within 30 days of season end
-            if days_until_end > 7 or days_until_end < 0:
+            # Show banner continuously from 21 days before season end
+            show_banner = 0 <= days_until_end <= 21
+            
+            if not show_banner:
                 return jsonify({
                     'success': True,
                     'has_pending': False,
@@ -365,7 +370,7 @@ def get_tournament_results_for_season(mysql, season_id=None):
             'Semifinals': 'semifinals',
             'Quarterfinals': 'quarterfinals',
             'Playoffs': 'playoffs',
-            'Regular Season': 'regular_season'
+            'Did Not Qualify': 'regular_season'
         }
         
         for result in results:


### PR DESCRIPTION
Completed KAN-103 and KAN-102
- Changed the match record "Regular Season" option to more accurate vocabulary (Did Not Qualify)
- Readjusted the match recording banner to continuously appear 21 days before a season ends.
- Readjusted the match recording emails to be send out 21 days before a season ends, a week before, and the last three days.