### PR TITLE
Refactor/KAN-23 Make Dashboard Calendar Function Like Landing Calendar

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/dashboard.py
+++ b/EsportsManagementTool/EsportsManagementTool/dashboard.py
@@ -27,9 +27,8 @@ def allowed_file(filename):
 Main route to allow all users to access the dashboard.
 """
 @app.route('/dashboard')
-@app.route('/dashboard/<int:year>/<int:month>')
 @login_required  # Added security
-def dashboard(year=None, month=None):
+def dashboard():
     # Get user data
     cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
     cursor.execute("SELECT * FROM users WHERE id = %s", (session['id'],))
@@ -55,144 +54,13 @@ def dashboard(year=None, month=None):
         WHERE user_id = %s
     """, (session['id'],))
     preferences = cursor.fetchone()
-
-    # Default to current month/year if not specified
-    if year is None or month is None:
-        today = datetime.now()
-        year = today.year
-        month = today.month
-
-    # Validate month and year
-    if month < 1 or month > 12:
-        flash('Invalid month!')
-        return redirect(url_for('dashboard'))
-    if year < 1900 or year > 2100:
-        flash('Year must be between 1900 and 2100!')
-        return redirect(url_for('dashboard'))
-
+    
     # Get today's date for highlighting
     today = datetime.now()
-    today_str = today.strftime('%Y-%m-%d')
-
-    # Get calendar information
-    cal.setfirstweekday(cal.SUNDAY)
-    month_calendar = cal.monthcalendar(year, month)
-    month_name = cal.month_name[month]
-
-    # Calculate previous and next month
-    if month == 1:
-        prev_month = 12
-        prev_year = year - 1
-    else:
-        prev_month = month - 1
-        prev_year = year
-
-    if month == 12:
-        next_month = 1
-        next_year = year + 1
-    else:
-        next_month = month + 1
-        next_year = year
 
     # Get events from database for this month - WITH VISIBILITY FILTERING
     try:
         user_id = session['id']
-
-        # Build visibility query
-        # An event is visible if:
-        # 1. It's not a scheduled event (schedule_id is NULL), OR
-        # 2. The user created the scheduled event (GM access), OR
-        # 3. It's a scheduled event with visibility = 'all_members', OR
-        # 4. It's a scheduled event with visibility = 'team' AND user is in that team, OR
-        # 5. It's a scheduled event with visibility = 'game_players' AND user is a player for that game, OR
-        # 6. It's a scheduled event with visibility = 'game_community' AND user is in that game's community
-
-        cursor.execute("""
-            SELECT ge.* 
-            FROM generalevents ge
-            LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
-            WHERE YEAR(ge.Date) = %s AND MONTH(ge.Date) = %s
-            AND (
-                -- Non-scheduled events (always visible)
-                ge.schedule_id IS NULL
-                OR
-                -- GM can see all events they created
-                se.created_by = %s
-                OR
-                -- Scheduled events with 'all_members' visibility
-                se.visibility = 'all_members'
-                OR
-                -- Scheduled events with 'team' visibility - user must be in the team
-                (se.visibility = 'team' AND EXISTS (
-                    SELECT 1 FROM team_members tm 
-                    WHERE tm.team_id = se.team_id 
-                    AND tm.user_id = %s
-                ))
-                OR
-                -- Scheduled events with 'game_players' visibility - user must be a player for that game
-                (se.visibility = 'game_players' AND EXISTS (
-                    SELECT 1 FROM team_members tm
-                    JOIN teams t ON tm.team_id = t.TeamID
-                    WHERE t.gameID = se.game_id
-                    AND tm.user_id = %s
-                ))
-                OR
-                -- Scheduled events with 'game_community' visibility - user must be in game's community
-                (se.visibility = 'game_community' AND EXISTS (
-                    SELECT 1 FROM in_communities ic
-                    WHERE ic.game_id = se.game_id
-                    AND ic.user_id = %s
-                ))
-            )
-            ORDER BY ge.Date, ge.StartTime
-        """, (year, month, user_id, user_id, user_id, user_id))
-
-        events = cursor.fetchall()
-
-        # Organize events by date
-        events_by_date = {}
-        for event in events:
-            date_str = event['Date'].strftime('%Y-%m-%d')
-
-            # Handle timedelta for StartTime and convert to 12-hour format
-            if event['StartTime']:
-                total_seconds = int(event['StartTime'].total_seconds())
-                hours = total_seconds // 3600
-                minutes = (total_seconds % 3600) // 60
-
-                # Check if this is an all-day event (00:00 to 23:59)
-                end_total_seconds = int(event['EndTime'].total_seconds()) if event['EndTime'] else 0
-                end_hours = end_total_seconds // 3600
-                end_minutes = (end_total_seconds % 3600) // 60
-
-                is_all_day = (hours == 0 and minutes == 0 and end_hours == 23 and end_minutes == 59)
-
-                # Convert to 12-hour format
-                period = 'AM' if hours < 12 else 'PM'
-                display_hours = hours if hours == 0 else (hours if hours <= 12 else hours - 12)
-                if display_hours == 0:
-                    display_hours = 12  # Handle midnight (0:00 -> 12:00 AM)
-
-                # Only show time if NOT all-day
-                time_str = None if is_all_day else f"{display_hours}:{minutes:02d} {period}"
-            else:
-                time_str = None
-                is_all_day = False
-
-            event_data = {
-                'id': event['EventID'],
-                'time': time_str,  # Will be None for all-day events
-                'title': event['EventName'],
-                'description': event['Description'] if event['Description'] else '',
-                'event_type': event['EventType'] if event.get('EventType') else 'Event',
-                'is_all_day': is_all_day,
-                'is_scheduled': event.get('is_scheduled', False),
-                'schedule_id': event.get('schedule_id')
-            }
-
-            if date_str not in events_by_date:
-                events_by_date[date_str] = []
-            events_by_date[date_str].append(event_data)
 
         # --- Admin Panel Stats ---
         total_users = active_users = admins = gms = players = developers = 0
@@ -272,16 +140,6 @@ def dashboard(year=None, month=None):
             user=user,
             is_verified=is_verified,
             preferences=preferences,
-            month_calendar=month_calendar,
-            month_name=month_name,
-            year=year,
-            month=month,
-            events_by_date=events_by_date,
-            today_str=today_str,
-            prev_year=prev_year,
-            prev_month=prev_month,
-            next_year=next_year,
-            next_month=next_month,
             total_users=total_users,
             active_users=active_users,
             current_season_name=current_season_name,

--- a/EsportsManagementTool/EsportsManagementTool/static/calendar.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/calendar.css
@@ -12,6 +12,7 @@
     display: grid;
     flex-direction: column;
     gap: 1rem;
+    position: relative;
 }
 
 .calendar-main {

--- a/EsportsManagementTool/EsportsManagementTool/static/calendar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/calendar.js
@@ -1,6 +1,5 @@
 /**
- * calendar.js
- * Landing Page Calendar System with improved error handling
+ * Handles logic & rendering for both calendars.
  */
 
 // Global variables - use unique names to avoid conflicts with dashboard scripts
@@ -227,13 +226,20 @@ function loadCalendarEvents() {
             calendarEventsData = data;
             displayEvents();
             updateTodayEvents();
+            revealCalendar();
         })
         .catch(error => {
             console.error('Error loading events:', error);
             calendarEventsData = {};
             displayEvents();
             updateTodayEvents();
+            revealCalendar();
         });
+}
+
+function revealCalendar() {
+    const calendarMain = document.querySelector('.calendar-container');
+    if (calendarMain) calendarMain.style.visibility = 'visible';
 }
 
 function displayEvents() {

--- a/EsportsManagementTool/EsportsManagementTool/static/calendar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/calendar.js
@@ -1,36 +1,17 @@
 /**
- * landing-calendar.js
+ * calendar.js
  * Landing Page Calendar System with improved error handling
  */
 
 // Global variables - use unique names to avoid conflicts with dashboard scripts
 let currentDate = new Date();
-let landingEventsData = {};  // Renamed from landingEventsData to avoid conflict with events.js
+let calendarEventsData = {};  
 let isUserLoggedIn = false;
 let clickOutsideHandler = null; // Listens for clicks outside of popups
 let activeAnchorElement = null;
 
 window.currentEventId = null;
 window.currentEventData = null;
-
-// Modal close functions (must be defined before modals.js loads)
-window.closeEventModal = function() {
-    const modal = document.getElementById('eventDetailsModal');
-    if (modal) {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto';
-    }
-    window.currentEventId = null;
-    window.currentEventData = null;
-};
-
-window.closeDayModal = function() {
-    const modal = document.getElementById('dayEventsModal');
-    if (modal) {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto';
-    }
-};
 
 // Scroll locking helper functions for event popups
 let scrollLockOffset = 0;
@@ -88,23 +69,24 @@ function handleDynamicReposition() {
     }
 }
 
-// Stub functions for dashboard-only modals
-window.closeCreateEventModal = function() {};
-window.closeCreateGameModal = function() {};
-window.closeCreateTeamModal = function() {};
-window.closeCommunityModal = function() {};
-window.closeAssignGMModal = function() {};
-window.closeAvatarModal = function() {};
-window.closeEditProfileModal = function() {};
-window.closeChangePasswordModal = function() {};
-window.closeDeleteConfirmModal = function() {};
-window.closeAddTeamMembersModal = function() {};
-window.closeCreateScheduledEventModal = function() {};
-window.closeAddVodModal = function() {};
-
-function closeEventModal() { window.closeEventModal(); }
-function closeDayModal() { window.closeDayModal(); }
-function closeEventPopup() {window.closeEventPopup(); }
+[
+    'closeCreateEventModal',
+    'closeCreateGameModal', 
+    'closeCreateTeamModal',
+    'closeCommunityModal',
+    'closeAssignGMModal',
+    'closeAvatarModal',
+    'closeEditProfileModal',
+    'closeChangePasswordModal',
+    'closeDeleteConfirmModal',
+    'closeAddTeamMembersModal',
+    'closeCreateScheduledEventModal',
+    'closeAddVodModal'
+].forEach(function(name) {
+    if (typeof window[name] !== 'function') {
+        window[name] = function() {};
+    }
+});
 
 // Initialization
 document.addEventListener('DOMContentLoaded', function() {
@@ -242,13 +224,13 @@ function loadCalendarEvents() {
         })
         .then(data => {
             console.log('Events loaded:', data);
-            landingEventsData = data;
+            calendarEventsData = data;
             displayEvents();
             updateTodayEvents();
         })
         .catch(error => {
             console.error('Error loading events:', error);
-            landingEventsData = {};
+            calendarEventsData = {};
             displayEvents();
             updateTodayEvents();
         });
@@ -261,8 +243,8 @@ function displayEvents() {
 
     let eventCount = 0;
 
-    Object.keys(landingEventsData).forEach(dateKey => {
-        const events = landingEventsData[dateKey];
+    Object.keys(calendarEventsData).forEach(dateKey => {
+        const events = calendarEventsData[dateKey];
         const container = document.getElementById(`events-${dateKey}`);
 
         if (!container || !events || events.length === 0) return;
@@ -320,7 +302,7 @@ function updateTodayEvents() {
     const day = String(today.getDate()).padStart(2, '0');
     const dateKey = `${year}-${month}-${day}`;
 
-    const todayEvents = landingEventsData[dateKey] || [];
+    const todayEvents = calendarEventsData[dateKey] || [];
     const container = document.getElementById('todayEventsList');
 
     if (!container) {
@@ -356,14 +338,14 @@ function updateTodayEvents() {
         item.appendChild(type);
 
         item.addEventListener('click', function() {
-            openEventModal(event.id);
+            openCalendarEventModal(event.id);
         });
 
         container.appendChild(item);
     });
 }
 
-function openEventModal(eventId) {
+function openCalendarEventModal(eventId) {
     const modal = document.getElementById('eventDetailsModal');
     const modalBody = document.getElementById('eventModalBody');
 
@@ -530,7 +512,7 @@ function openDayModal(dateKey, dateDisplay) {
     const body = document.getElementById('dayModalBody');
 
     title.textContent = `Events on ${dateDisplay}`;
-    const events = landingEventsData[dateKey] || [];
+    const events = calendarEventsData[dateKey] || [];
 
     if (events.length === 0) {
         body.innerHTML = '<p style="color: var(--text-secondary);">No events on this day</p>';
@@ -538,7 +520,7 @@ function openDayModal(dateKey, dateDisplay) {
         let html = '';
         events.forEach(event => {
             html += `
-                <div class="modal-event-item" onclick="closeDayModal(); openEventModal(${event.id});">
+                <div class="modal-event-item" onclick="closeDayModal(); openCalendarEventModal(${event.id});">
                     ${event.time ? `<div class="modal-event-time">${event.time}</div>` : ''}
                     <div class="modal-event-title">${event.title}</div>
                     ${event.description ? `<div class="modal-event-description">${event.description}</div>` : ''}
@@ -870,4 +852,29 @@ async function toggleEventSubscription() {
         console.error('Error toggling subscription:', err);
         alert('Failed to toggle subscription.');
     }
+}
+
+// These are defined at the END so they always win over anything modals.js set earlier
+window.closeEventModal = function() {
+    const modal = document.getElementById('eventDetailsModal');
+    if (modal) modal.style.display = 'none';
+    window.currentEventId = null;
+    window.currentEventData = null;
+    document.body.style.overflow = '';
+};
+
+window.closeDayModal = function() {
+    const modal = document.getElementById('dayEventsModal');
+    if (modal) modal.style.display = 'none';
+    document.body.style.overflow = '';
+};
+
+function closeEventModal() { window.closeEventModal(); }
+function closeDayModal() { window.closeDayModal(); }
+function closeEventPopup() { window.closeEventPopup(); }
+
+window.openCalendarEventModal = openCalendarEventModal;
+
+if (typeof window.openEventModal !== 'function') {
+    window.openEventModal = openCalendarEventModal;
 }

--- a/EsportsManagementTool/EsportsManagementTool/static/calendar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/calendar.js
@@ -239,6 +239,8 @@ function loadCalendarEvents() {
 
 function revealCalendar() {
     const calendarMain = document.querySelector('.calendar-container');
+    const spinner = document.getElementById('calendarLoadingSpinner');
+    if (spinner) spinner.style.display = 'none';
     if (calendarMain) calendarMain.style.visibility = 'visible';
 }
 

--- a/EsportsManagementTool/EsportsManagementTool/static/dashboard.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/dashboard.js
@@ -68,13 +68,6 @@ document.addEventListener('DOMContentLoaded', function() {
  */
 function initializeDashboardModules() {
 
-    // Initialize events module (from events.js)
-    // Only initializes if both the function and server data are available
-    if (typeof initializeEventsModule === 'function' && typeof eventsDataFromServer !== 'undefined') {
-        initializeEventsModule(eventsDataFromServer);
-        console.log('Events module initialized');
-    }
-
     // Initialize admin panel if admin tab exists (from admin-panel.js)
     // Only initializes for users with admin access
     const adminTab = document.querySelector('[data-tab="admin"]');
@@ -82,9 +75,16 @@ function initializeDashboardModules() {
         initializeAdminPanel();
         console.log('Admin panel initialized');
     }
-
     // Note: Other modules (communities, profile, etc.) initialize themselves
     // or are initialized by their respective loaded scripts
+    
+    // Initialize events module on page load
+    const eventsTab = document.querySelector('[data-tab="events"]');
+    if (eventsTab && typeof loadEvents === 'function') {
+        setTimeout(() => {
+            loadEvents();
+    }, 150);
+    }
 }
 
 // ============================================

--- a/EsportsManagementTool/EsportsManagementTool/static/dashboard.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/dashboard.js
@@ -80,10 +80,18 @@ function initializeDashboardModules() {
     
     // Initialize events module on page load
     const eventsTab = document.querySelector('[data-tab="events"]');
-    if (eventsTab && typeof loadEvents === 'function') {
-        setTimeout(() => {
-            loadEvents();
-    }, 150);
+    if (eventsTab) {
+        // Initialize events module (from events.js)
+        if (typeof initializeEventsModule === 'function') {
+            initializeEventsModule(typeof eventsDataFromServer !== 'undefined' ? eventsDataFromServer : {});
+            console.log('Events module initialized');
+        }
+
+        if (typeof loadEvents === 'function') {
+            setTimeout(() => {
+                loadEvents();
+            }, 150);
+        }
     }
 }
 

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -1341,7 +1341,7 @@ async function openEventModal(eventId, source = 'events') {
     const spinner = document.getElementById('eventLoadingSpinner');
     const content = document.getElementById('eventDetailsContent');
     const deleteBtn = document.getElementById('deleteEventBtn');
-    const titleElement = document.getElementById('eventModalsTitle');
+    const titleElement = document.getElementById('eventModalTitle');
 
     EventState.currentEventId = eventId;
     EventState.deletionSource = source;

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -1341,7 +1341,7 @@ async function openEventModal(eventId, source = 'events') {
     const spinner = document.getElementById('eventLoadingSpinner');
     const content = document.getElementById('eventDetailsContent');
     const deleteBtn = document.getElementById('deleteEventBtn');
-    const titleElement = document.getElementById('eventDetailsTitle');
+    const titleElement = document.getElementById('eventModalsTitle');
 
     EventState.currentEventId = eventId;
     EventState.deletionSource = source;
@@ -1981,7 +1981,7 @@ function toggleEditMode() {
     const editForm = document.getElementById('eventEditForm');
     const editBtn = document.getElementById('editEventBtn');
     const deleteBtn = document.getElementById('deleteEventBtn');
-    const titleElement = document.getElementById('eventDetailsTitle');
+    const titleElement = document.getElementById('eventModalTitle');
 
     // Hide view mode, show edit mode
     setElementDisplay(content, 'none');

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -349,6 +349,14 @@ function setElementDisplay(element, displayValue) {
 }
 
 /**
+ * Enable a dropdown element (re-enable after loading state)
+ * @param {HTMLElement|null} dropdown - Dropdown element to enable
+ */
+function enableDropdown(dropdown) {
+    if (dropdown) dropdown.disabled = false;
+}
+
+/**
  * Escape single quotes in strings for safe HTML attribute use
  * @param {string} str - String to escape
  * @returns {string} Escaped string

--- a/EsportsManagementTool/EsportsManagementTool/static/index.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/index.css
@@ -1,29 +1,4 @@
 /* ============================================
-   GLOBAL COLOR THEME VARIABLES
-   ============================================ */
-:root {
-    /* Tournament (Purple) */
-    --event-tournament: #8b5cf6;
-    --event-tournament-light: rgba(167, 139, 250, 0.2);
-
-    /* Match (Red) */
-    --event-match: #ef4444;
-    --event-match-light: rgba(252, 165, 165, 0.2);
-
-    /* Practice (Green) */
-    --event-practice: #22c55e;
-    --event-practice-light: rgba(134, 239, 172, 0.2);
-
-    /* Event (Blue) */
-    --event-event: #79bdd9;
-    --event-event-light: rgba(147, 197, 253, 0.2);
-
-    /* Misc (Yellow) */
-    --event-misc: #eab308;
-    --event-misc-light: rgba(250, 204, 21, 0.2);
-}
-
-/* ============================================
    LANDING PAGE STYLES
    ORGANIZED BY CLAUDEAI
    ============================================ */
@@ -61,58 +36,6 @@
     .calendar-section .calendar-sidebar {
         grid-template-columns: 1fr;
     }
-}
-
-/* Event Details Modal - Icon Coloring (matches dashboard structure) */
-.event-card-details[data-event-type="tournament"] .event-detail-icon {
-    background: var(--event-tournament-light);
-    color: var(--event-tournament);
-}
-
-.event-card-details[data-event-type="match"] .event-detail-icon {
-    background: var(--event-match-light);
-    color: var(--event-match);
-}
-
-.event-card-details[data-event-type="practice"] .event-detail-icon {
-    background: var(--event-practice-light);
-    color: var(--event-practice);
-}
-
-.event-card-details[data-event-type="event"] .event-detail-icon {
-    background: var(--event-event-light);
-    color: var(--event-event);
-}
-
-.event-card-details[data-event-type="misc"] .event-detail-icon {
-    background: var(--event-misc-light);
-    color: var(--event-misc);
-}
-
-/* Event Details Popup - Icon Coloring (matches dashboard structure) */
-.event-popup-details[data-event-type="tournament"] .popup-icon {
-    background: var(--event-tournament-light);
-    color: var(--event-tournament);
-}
-
-.event-popup-details[data-event-type="match"] .popup-icon {
-    background: var(--event-match-light);
-    color: var(--event-match);
-}
-
-.event-popup-details[data-event-type="practice"] .popup-icon {
-    background: var(--event-practice-light);
-    color: var(--event-practice);
-}
-
-.event-popup-details[data-event-type="event"] .popup-icon {
-    background: var(--event-event-light);
-    color: var(--event-event);
-}
-
-.event-popup-details[data-event-type="misc"] .popup-icon {
-    background: var(--event-misc-light);
-    color: var(--event-misc);
 }
 
 /* Textured background */

--- a/EsportsManagementTool/EsportsManagementTool/static/modals.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/modals.css
@@ -147,7 +147,9 @@
     color: var(--text-secondary);
     font-size: 0.875rem;
     line-height: 1.4;
-}
+    word-break: break-word;
+    overflow-wrap: break-word;
+}   
 
 .modal-event-meta {
     display: flex;
@@ -222,6 +224,14 @@
     color: var(--text-primary);
     line-height: 1.5;
     margin: 0;
+}
+
+.event-detail-value {
+    color: var(--text-primary);
+    flex: 1;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    min-width: 0;
 }
 
 /* --------------------------------------------
@@ -863,6 +873,64 @@
     border-right: none;
     filter: drop-shadow(1px 0 0 var(--border-color, #222));
 }
+
+/* --------------------------------------------
+   ICON COLORING
+   Event Modal and Popup Details
+   -------------------------------------------- */
+
+/* Event Details Modal - Icon Coloring (matches dashboard structure) */
+.event-card-details[data-event-type="tournament"] .event-detail-icon {
+    background: var(--event-tournament-light);
+    color: var(--event-tournament);
+}
+
+.event-card-details[data-event-type="match"] .event-detail-icon {
+    background: var(--event-match-light);
+    color: var(--event-match);
+}
+
+.event-card-details[data-event-type="practice"] .event-detail-icon {
+    background: var(--event-practice-light);
+    color: var(--event-practice);
+}
+
+.event-card-details[data-event-type="event"] .event-detail-icon {
+    background: var(--event-event-light);
+    color: var(--event-event);
+}
+
+.event-card-details[data-event-type="misc"] .event-detail-icon {
+    background: var(--event-misc-light);
+    color: var(--event-misc);
+}
+
+/* Event Details Popup - Icon Coloring (matches dashboard structure) */
+.event-popup-details[data-event-type="tournament"] .popup-icon {
+    background: var(--event-tournament-light);
+    color: var(--event-tournament);
+}
+
+.event-popup-details[data-event-type="match"] .popup-icon {
+    background: var(--event-match-light);
+    color: var(--event-match);
+}
+
+.event-popup-details[data-event-type="practice"] .popup-icon {
+    background: var(--event-practice-light);
+    color: var(--event-practice);
+}
+
+.event-popup-details[data-event-type="event"] .popup-icon {
+    background: var(--event-event-light);
+    color: var(--event-event);
+}
+
+.event-popup-details[data-event-type="misc"] .popup-icon {
+    background: var(--event-misc-light);
+    color: var(--event-misc);
+}
+
 
 /* --------------------------------------------
    ANIMATIONS

--- a/EsportsManagementTool/EsportsManagementTool/templates/base.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/base.html
@@ -25,6 +25,17 @@
             --text-primary: #ffffff;
             --text-secondary: #a0a0a0;
             --hover-bg: #252525;
+            
+            --event-tournament: #8b5cf6;
+            --event-tournament-light: rgba(167, 139, 250, 0.2);
+            --event-match: #ef4444;
+            --event-match-light: rgba(252, 165, 165, 0.2);
+            --event-practice: #22c55e;
+            --event-practice-light: rgba(134, 239, 172, 0.2);
+            --event-event: #79bdd9;
+            --event-event-light: rgba(147, 197, 253, 0.2);
+            --event-misc: #eab308;
+            --event-misc-light: rgba(250, 204, 21, 0.2);
         }
 
         body {
@@ -374,7 +385,7 @@
     <div id="eventDetailsModal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h2 id="eventDetailsTitle">Event Details</h2>
+                <h2 id="eventModalTitle">Event Details</h2>
                 <div style="display: flex; gap: 0.5rem; align-items: center;">
                     <button id="editEventBtn"
                             class="btn-edit-event"
@@ -393,7 +404,7 @@
                     </button>
                 </div>
             </div>
-            <div class="modal-body" id="eventDetailsBody">
+            <div class="modal-body" id="eventModalBody">
                 <div id="eventEditForm" style="display: none;"></div>
                 <div id="eventLoadingSpinner" class="loading-spinner">
                     <i class="fas fa-spinner fa-spin"></i>

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -87,15 +87,15 @@
                 <div class="calendar-wrapper">
                     <!-- Calendar Navigation -->
                     <div class="calendar-navigation">
-                        <a href="{{ url_for('dashboard', year=prev_year, month=prev_month) }}" class="nav-button">
+                        <button class="nav-button" id="prevMonth">
                             <i class="fas fa-chevron-left"></i>
                             <span>Previous</span>
-                        </a>
-                        <h1 class="calendar-month-year">{{ month_name }} {{ year }}</h1>
-                        <a href="{{ url_for('dashboard', year=next_year, month=next_month) }}" class="nav-button">
+                        </button>
+                        <h2 class="calendar-month-year" id="currentMonthYear"></h2>
+                        <button class="nav-button" id="nextMonth">
                             <span>Next</span>
                             <i class="fas fa-chevron-right"></i>
-                        </a>
+                        </button>
                     </div>
 
                     <!-- Days of week header -->
@@ -110,58 +110,16 @@
                     </div>
 
                     <!-- Calendar grid -->
-                    <div class="calendar-grid">
-                        {% for week in month_calendar %}
-                            {% for day in week %}
-                                {% if day == 0 %}
-                                    <div class="calendar-cell empty"></div>
-                                {% else %}
-                                    {% set day_date = '%04d-%02d-%02d'|format(year, month, day) %}
-                                    {% set is_today = (day_date == today_str) %}
-
-                                    <div class="calendar-cell {% if is_today %}today{% endif %}">
-                                        <div class="day-number">{{ day }}</div>
-
-                                        <div class="events-container">
-                                            {% if day_date in events_by_date %}
-                                                {% set day_events = events_by_date[day_date] %}
-
-                                                {% for event in day_events[:3] %}
-                                                    <div class="event-link" onclick="openEventModal({{ event.id }}, 'calendar')">
-                                                        <div class="event {{ event.event_type|lower }} {% if event.is_scheduled %}scheduled-event{% endif %}"
-                                                             data-event-type="{{ event.event_type|lower }}"
-                                                             {% if event.is_scheduled %}data-scheduled="true" data-schedule-id="{{ event.schedule_id }}"{% endif %}
-                                                             title="Click to view details"
-                                                             {% if not event.time %}class="all-day"{% endif %}>
-                                                            <div class="event-title">{{ event.title }}</div>
-                                                            {% if event.time %}
-                                                                <div class="event-time">{{ event.time }}</div>
-                                                            {% endif %}
-                                                        </div>
-                                                    </div>
-                                                {% endfor %}
-
-                                                {% if day_events|length > 3 %}
-                                                    <div class="event-overflow"
-                                                         onclick="openDayModal('{{ day_date }}', '{{ month_name }} {{ day }}, {{ year }}')"
-                                                         style="cursor: pointer; color: var(--stockton-blue); text-decoration: underline;">
-                                                        +{{ day_events|length - 3 }} more
-                                                    </div>
-                                                {% endif %}
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% endif %}
-                            {% endfor %}
-                        {% endfor %}
+                    <div class="calendar-grid" id="calendarGrid">
+                        <!-- Populated by calendar.js -->
                     </div>
 
                     <!-- Calendar Footer -->
-<!--                    <div class="calendar-footer">-->
-<!--                        <a href="{{ url_for('dashboard') }}" class="today-button">-->
-<!--                            <i class="fas fa-calendar-day"></i> Jump to Today-->
-<!--                        </a>-->
-<!--                    </div>-->
+                         <!-- <div class="calendar-footer"> -->
+                            <!-- <a href="{{ url_for('dashboard') }}" class="today-button"> -->
+                                <!-- <i class="fas fa-calendar-day"></i> Jump to Today -->
+                            <!-- </a> -->
+                        <!-- </div> -->
                 </div>
             </div>
 
@@ -200,28 +158,9 @@
                 <!-- Today's Events Card -->
                 <div class="sidebar-card">
                     <h3><i class="fas fa-calendar-day"></i> Today's Events</h3>
-                    {% set today_events = events_by_date.get(today_str, []) %}
-                    {% if today_events %}
-                        <div class="today-events-list">
-                            {% for event in today_events %}
-                                <div class="today-event-item" onclick="openEventModal({{ event.id }}, 'calendar')">
-                                    <div class="today-event-time">
-                                        {% if event.time %}
-                                            <i class="fas fa-clock"></i> {{ event.time }}
-                                        {% else %}
-                                            <i class="fas fa-calendar"></i> All Day
-                                        {% endif %}
-                                    </div>
-                                    <div class="today-event-title">{{ event.title }}</div>
-                                    <span class="today-event-type {{ event.event_type|lower }}">{{ event.event_type }}</span>
-                                </div>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        <p style="color: var(--text-secondary); font-size: 0.875rem; margin: 0;">
-                            No events scheduled for today.
-                        </p>
-                    {% endif %}
+                    <div class="today-events-list" id="todayEventsList">
+                        <p style="color: var(--text-secondary); font-size: 0.875rem;">No events today</p>   
+                    </div>
                 </div>
             </div>
         </div>
@@ -1541,12 +1480,12 @@
 <div id="dayEventsModal" class="modal">
     <div class="modal-content">
         <div class="modal-header">
-            <h2 id="modalDayTitle"></h2>
+            <h2 id="dayModalTitle"></h2>
             <button class="modal-close" onclick="closeDayModal()">
                 <i class="fas fa-times"></i>
             </button>
         </div>
-        <div class="modal-body" id="modalEventsList">
+        <div class="modal-body" id="dayModalBody">
             <!-- Events will be populated here -->
         </div>
     </div>
@@ -2085,6 +2024,7 @@
 <script src="{{ url_for('static', filename='tournament-results.js') }}"></script>
 <!-- Must load second-to-last -->
 <script src="{{ url_for('static', filename='modals.js') }}"></script>
+<script src="{{ url_for('static', filename='calendar.js') }}"></script>
 <!-- Must load last -->
 <script src="{{ url_for('static', filename='dashboard.js') }}"></script>
 
@@ -2097,8 +2037,11 @@
 
     // Set global user context for events module
     window.currentUserId = {{ session.id }};
-
-    // Events data for calendar
-    const eventsDataFromServer = {{ events_by_date | tojson }};
+    
+    document.addEventListener('click', function(e) {
+        if (!e.target.classList.contains('modal')) return;
+        const closeBtn = e.target.querySelector('.modal-header .modal-close, .modal-header .close');
+        if (closeBtn) closeBtn.click();
+    });
 </script>
 {% endblock %}

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -81,6 +81,11 @@
 
     <!-- Calendar Tab -->
     <div id="calendar" class="tab-content active">
+        <!-- Calendar Loading Spinner -->
+        <div id="calendarLoadingSpinner" style="text-align: center; padding: 3rem; color: var(--text-secondary);">
+            <i class="fas fa-spinner fa-spin" style="font-size: 2rem;"></i>
+            <p style="margin-top: 0.75rem; font-size: 0.9rem;">Loading calendar...</p>
+        </div>
         <div class="calendar-container" style="visibility: hidden;">
             <!-- Main Calendar Section -->
             <div class="calendar-main">

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -81,7 +81,7 @@
 
     <!-- Calendar Tab -->
     <div id="calendar" class="tab-content active">
-        <div class="calendar-container">
+        <div class="calendar-container" style="visibility: hidden;">
             <!-- Main Calendar Section -->
             <div class="calendar-main">
                 <div class="calendar-wrapper">

--- a/EsportsManagementTool/EsportsManagementTool/templates/index.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/index.html
@@ -240,8 +240,8 @@
     window.currentUserId = {{ session.id }};
     {% endif %}
 </script>
-<!-- Load landing-calendar.js FIRST to define modal close handlers -->
-<script src="{{ url_for('static', filename='landing-calendar.js') }}"></script>
+<!-- Load calendar.js FIRST to define modal close handlers -->
+<script src="{{ url_for('static', filename='calendar.js') }}"></script>
 <!-- Then load modals.js which references those handlers -->
 <script src="{{ url_for('static', filename='modals.js') }}"></script>
 <!-- DO NOT load events.js - it conflicts with landing calendar functions -->

--- a/EsportsManagementTool/EsportsManagementTool/templates/index.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/index.html
@@ -53,7 +53,7 @@
             <p>Stay up to date with matches, practices, and community events</p>
         </div>
 
-        <div class="calendar-container">
+        <div class="calendar-container" style="visibility: hidden;">
             <!-- Calendar Navigation -->
             <div class="calendar-navigation">
                 <a href="#" class="nav-button" id="prevMonth">


### PR DESCRIPTION
### KAN-23 Dashboard Calendar Overhaul

---

#### Short Summary:
Within this PR, both the landing calendar and dashboard calendar use the same logic when operating. Both calendars are now loaded through the client for more responsive interaction. Dead code has been removed and both calendars function the exact same way.

---

#### Refactors:
- Renamed `landing-calendar.js` to `calendar.js`.
- Fully consolidated all event modals/popup logic within `calendar.js` for the use of both calendars.
- Optimized loading times when changing monthly view in dashboard calendar by removing server-sided calendar loading for the dashboard and made both client-sided (does not have an API call per tab and loads much faster).
- Relocated icon coloring for event detail modals and popup details to `modals.css` for the landing page calendar.
- Relocated icon coloring for event detail modals and popup details to `base.html` for the dashboard calendar.
- Renamed numerous variables for better naming conventions.
- General cleanup to remove dead code from the old dashboard calendar (data fetches, loading logic, modal logic, etc.).
- Both calendars are hidden until fully able to be loaded then shown to reduce janky rendering visuals.
- A loading spinner has been added to the dashboard calendar prior to the calendar loading after the page is initialized.

---

#### Fixed Bugs:
- Fixed landing calendar event detail modals (previously wasn't loading in properly).
- Fixed a bug where the 'X' button was not working on generic modals (such as those for create events, add team member, etc.) that caused the screen to remain scroll locked even when the modal is closed.
- Fixed a bug where the date modals for both calendars would not properly load the event details modal once clicked.
- Fixed a bug with icon coloring not working for event modals and pop ups.
- Fixed a bug with popups not aligning next to the event properly in the dashboard calendar.
- Due to issues with events, teams, etc. and the dashboard calendar using the same generic modal, events would load before calendar which caused overwriting issues. The bug was fixed by distinguishing the proper "version" of the modal when the dashboard calendar loads.
- Fixed descriptions within the event details modal by adding page breaks.
- Fixed creating events being damaged by calendar modal logic (funny I know), events should work normally again.