### PR TITLE
"Create Team" Button Migration, Fixed Sidebar Filters, and Added Character Limit Display

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/static/dashboard.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/dashboard.js
@@ -55,6 +55,10 @@ document.addEventListener('DOMContentLoaded', function() {
             }, 100);
         }
     }
+
+    // Character Counter        
+    attachCharacterCounter('gameDescription', 250);
+    attachCharacterCounter('matchNotes', 250);
 });
 
 // ============================================

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -1717,6 +1717,9 @@ function openCreateEventModal() {
     setElementDisplay(formMessage, 'none');
     setElementDisplay(leagueGroup, 'none'); // ADD THIS LINE - Hide league field initially
     clearSelectedGames('create');
+    
+    // Character Counter
+    attachCharacterCounter('eventDescription', 250);
 
     // Load games after modal is rendered
     setTimeout(() => {
@@ -2013,6 +2016,10 @@ function createEditForm() {
     
     // Setup location dropdown
     setupEditLocationDropdown(event.location);
+
+    // Character Counter
+    attachCharacterCounter('editDescription', 250);
+
     
     // **MOVED: Wait for DOM to be ready before calling these functions**
     setTimeout(() => {

--- a/EsportsManagementTool/EsportsManagementTool/static/game.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/game.js
@@ -155,14 +155,6 @@ function createGameCard(game, isAdmin) {
                 <i class="fas fa-user-plus"></i> Join Community
            </button>`;
 
-    // Create Team button (only for GMs of this specific game)
-    const createTeamButtonHTML = isGameManager
-        ? `<button class="btn btn-primary"
-                    onclick="checkSeasonBeforeTeamCreation(${game.GameID}, '${escapeHtml(game.GameTitle)}', '${game.TeamSizes}')">
-                <i class="fas fa-plus"></i> Create Team
-           </button>`
-        : '';
-
     // Member badge for joined communities
     const memberBadge = isMember
         ? `<span class="member-badge">
@@ -198,7 +190,6 @@ function createGameCard(game, isAdmin) {
         <div class="community-card-actions">
             <a class="btn btn-primary" href="/community/${game.GameID}">View Details</a>
             ${joinButtonHTML}
-            ${createTeamButtonHTML}
         </div>
     `;
 

--- a/EsportsManagementTool/EsportsManagementTool/static/manage-communities.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/manage-communities.js
@@ -384,6 +384,9 @@ function showCommunityForm(community = null) {
             this.value = this.value.toUpperCase();
         });
     }
+
+    // Character Counter
+    attachCharacterCounter('communityDescription', 250);
 }
 
 // Submit community creation/editing form

--- a/EsportsManagementTool/EsportsManagementTool/static/modals.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/modals.css
@@ -947,3 +947,11 @@
         grid-column: span 1 !important;
     }
 }
+
+/* Character counter displayed below text boxes */
+.char-counter {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-align: right;
+    margin-top: 0.25rem;
+}

--- a/EsportsManagementTool/EsportsManagementTool/static/scheduled-events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/scheduled-events.js
@@ -467,6 +467,9 @@ function openCreateScheduledEventModal() {
         eventTypeSelect.addEventListener('change', handleEventTypeChangeForLeague);
     }
 
+    // Character Counter
+    attachCharacterCounter('scheduledDescription', 250);
+
     // Show modal
     modal.style.display = 'block';
     document.body.style.overflow = 'hidden';
@@ -1073,6 +1076,9 @@ function openEditScheduleMode(scheduleId) {
 
     // Attach form submit handler
     document.getElementById('editScheduleForm').addEventListener('submit', handleEditScheduleSubmit);
+
+    // Character Counter
+    attachCharacterCounter('editScheduleDescription', 250);
 
     // Hide edit/delete buttons while in edit mode
     document.getElementById('editScheduleBtn').style.display = 'none';

--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.css
@@ -581,6 +581,61 @@
 }
 
 /* --------------------------------------------
+   CREATE TEAM & GAME PICKER 
+   Teams sidebar header button and game select
+   modal styles
+   -------------------------------------------- */
+
+/* Create Team button in sidebar header */
+.btn-create-team-sidebar {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.8125rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+/* Game picker modal options */
+.game-picker-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.game-picker-option {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: var(--background-secondary, #1e2130);
+    border: 1px solid var(--border-color, #2d3148);
+    border-radius: 8px;
+    cursor: pointer;
+    color: var(--text-primary);
+    text-align: left;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.game-picker-option:hover {
+    background: var(--hover-bg, #252840);
+    border-color: var(--stockton-blue, #79bde9);
+}
+
+.game-picker-icon {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.game-picker-title {
+    font-weight: 600;
+    font-size: 0.9375rem;
+}
+
+/* --------------------------------------------
    RESPONSIVE DESIGN
    Mobile and tablet adaptations
    -------------------------------------------- */

--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
@@ -127,11 +127,8 @@ async function initializeViewSwitcher() {
             const validStoredView = window.availableViews.find(v => v.value === storedView);
             window.currentView = validStoredView ? storedView : window.availableViews[0].value;
 
-            if (data.has_multiple) {
-                renderViewSwitcher();
-            } else {
-                hideViewSwitcher();
-            }
+            // Always render — any user associated with teams sees the dropdown
+            renderViewSwitcher();
 
             initializeDivisionFilter();
             initializePastSeasonFilter();
@@ -162,33 +159,28 @@ function renderViewSwitcher() {
         const option = document.createElement('option');
         option.value = view.value;
         option.textContent = view.label;
+        option.setAttribute('data-base-label', view.label);
         if (view.value === window.currentView) {
             option.selected = true;
         }
         viewSelect.appendChild(option);
     });
 
-    const isAdmin = window.userPermissions?.is_admin || window.userPermissions.is_developer || false;
+    const isAdmin = window.userPermissions?.is_admin || window.userPermissions?.is_developer || false;
 
-    // Add division filter option for admins
     if (isAdmin) {
         const divisionOption = document.createElement('option');
         divisionOption.value = 'division';
         divisionOption.textContent = 'Divisions';
-        if (window.currentView === 'division') {
-            divisionOption.selected = true;
-        }
+        divisionOption.setAttribute('data-base-label', 'Divisions');
+        if (window.currentView === 'division') divisionOption.selected = true;
         viewSelect.appendChild(divisionOption);
-    }
 
-    // Add past seasons option for admins/devs
-    if (isAdmin) {
         const pastSeasonOption = document.createElement('option');
         pastSeasonOption.value = 'past_seasons';
         pastSeasonOption.textContent = 'Past Seasons';
-        if (window.currentView === 'past_seasons') {
-            pastSeasonOption.selected = true;
-        }
+        pastSeasonOption.setAttribute('data-base-label', 'Past Seasons');
+        if (window.currentView === 'past_seasons') pastSeasonOption.selected = true;
         viewSelect.appendChild(pastSeasonOption);
     }
 
@@ -268,7 +260,6 @@ async function loadTeams() {
     const sidebarLoading = document.getElementById('teamsSidebarLoading');
     const sidebarList = document.getElementById('teamsSidebarList');
     const sidebarEmpty = document.getElementById('teamsSidebarEmpty');
-    const sidebarSubtitle = document.querySelector('.teams-subtitle');
 
     if (window.availableViews.length === 0) {
         await initializeViewSwitcher();
@@ -291,9 +282,7 @@ async function loadTeams() {
         sidebarList.style.display = 'none';
         sidebarEmpty.style.display = 'block';
 
-        if (sidebarSubtitle) {
-            sidebarSubtitle.textContent = 'Past Seasons (0)';
-        }
+        updateDropdownCount(0);
 
         if (sidebarEmpty) {
             sidebarEmpty.innerHTML = `<i class="fas fa-calendar"></i><p>Select a past season to view teams</p>`;
@@ -304,7 +293,7 @@ async function loadTeams() {
     // Check cache first
     if (teamsCache[cacheKey] && isCacheFresh(cacheKey)) {
         console.log('Using cached teams data');
-        renderFromCache(teamsCache[cacheKey], sidebarLoading, sidebarList, sidebarEmpty, sidebarSubtitle);
+        renderFromCache(teamsCache[cacheKey], sidebarLoading, sidebarList, sidebarEmpty);
         return;
     }
 
@@ -318,9 +307,7 @@ async function loadTeams() {
         let url = `/api/teams/sidebar?view=${window.currentView}`;
 
         // Add season parameter if filtering past seasons
-        if (selectedSeasonId) {
-            url += `&season_id=${selectedSeasonId}`;
-        }
+        if (selectedSeasonId) url += `&season_id=${selectedSeasonId}`;
 
         const response = await fetch(url);
         const data = await response.json();
@@ -344,40 +331,25 @@ async function loadTeams() {
 
             window.allTeamsData = teamsToDisplay;
 
-            if (sidebarSubtitle) {
-                const viewLabel = getSubtitleForView(window.currentView, teamsToDisplay.length);
-                sidebarSubtitle.textContent = viewLabel;
-            }
+            updateDropdownCount(teamsToDisplay.length);
 
             if (teamsToDisplay.length > 0) {
                 renderTeamsSidebar(teamsToDisplay);
                 sidebarLoading.style.display = 'none';
                 sidebarList.style.display = 'flex';
             } else {
-                if (sidebarSubtitle) {
-                    const viewLabel = getSubtitleForView(window.currentView, 0);
-                    sidebarSubtitle.textContent = viewLabel;
-                }
-
+                updateDropdownCount(0);
                 if (sidebarEmpty) {
-                    const emptyMessage = getEmptyMessageForView(window.currentView);
-                    sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${emptyMessage}</p>`;
+                    sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${getEmptyMessageForView(window.currentView)}</p>`;
                 }
-
                 sidebarLoading.style.display = 'none';
                 sidebarEmpty.style.display = 'block';
             }
         } else {
-            if (sidebarSubtitle) {
-                const viewLabel = getSubtitleForView(window.currentView, 0);
-                sidebarSubtitle.textContent = viewLabel;
-            }
-
+            updateDropdownCount(0);
             if (sidebarEmpty) {
-                const emptyMessage = getEmptyMessageForView(window.currentView);
-                sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${emptyMessage}</p>`;
+                sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${getEmptyMessageForView(window.currentView)}</p>`;
             }
-
             sidebarLoading.style.display = 'none';
             sidebarEmpty.style.display = 'block';
         }
@@ -391,29 +363,20 @@ async function loadTeams() {
 /**
  * Helper function to render from cached data
  */
-function renderFromCache(cachedTeams, sidebarLoading, sidebarList, sidebarEmpty, sidebarSubtitle) {
+function renderFromCache(cachedTeams, sidebarLoading, sidebarList, sidebarEmpty) {
     window.allTeamsData = cachedTeams;
 
-    if (sidebarSubtitle) {
-        const viewLabel = getSubtitleForView(window.currentView, cachedTeams.length);
-        sidebarSubtitle.textContent = viewLabel;
-    }
+    updateDropdownCount(cachedTeams.length);
 
     if (cachedTeams.length > 0) {
         renderTeamsSidebar(cachedTeams);
         sidebarLoading.style.display = 'none';
         sidebarList.style.display = 'flex';
     } else {
-        if (sidebarSubtitle) {
-            const viewLabel = getSubtitleForView(window.currentView, 0);
-            sidebarSubtitle.textContent = viewLabel;
-        }
-
+        updateDropdownCount(0);
         if (sidebarEmpty) {
-            const emptyMessage = getEmptyMessageForView(window.currentView);
-            sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${emptyMessage}</p>`;
+            sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${getEmptyMessageForView(window.currentView)}</p>`;
         }
-
         sidebarLoading.style.display = 'none';
         sidebarEmpty.style.display = 'block';
     }
@@ -536,6 +499,23 @@ function renderTeamsSidebar(teams) {
 
         sidebarList.appendChild(teamItem);
     });
+}
+
+/**
+ * Update the currently selected dropdown option to show the team count.
+ */
+function updateDropdownCount(count) {
+    const viewSelect = document.getElementById('teamViewSelect');
+    if (!viewSelect) return;
+
+    const selectedOption = viewSelect.options[viewSelect.selectedIndex];
+    if (!selectedOption) return;
+
+    const baseLabel = selectedOption.getAttribute('data-base-label')
+        || selectedOption.textContent.replace(/\s*\(\d+\)$/, '').trim();
+
+    selectedOption.setAttribute('data-base-label', baseLabel);
+    selectedOption.textContent = `${baseLabel} (${count})`;
 }
 
 // ============================================
@@ -1213,6 +1193,7 @@ window.invalidateTeamsCache = invalidateTeamsCache;
 window.isCacheFresh = isCacheFresh;
 window.openCreateTeam = openCreateTeam;
 window.closeGamePickerModal = closeGamePickerModal;
+window.updateDropdownCount = updateDropdownCount;
 
 //Past Season Exports
 window.initializePastSeasonFilter = initializePastSeasonFilter;

--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
@@ -1089,6 +1089,110 @@ function handleDivisionFilterChange(event) {
 }
 
 // ============================================
+// CREATE TEAM FROM TEAMS TAB
+// ============================================
+
+/**
+ * Open create team flow from the Teams sidebar.
+ * If the GM manages exactly one game, goes straight to team creation.
+ * If they manage multiple, shows a game-picker first.
+ * Admins/developers see all games.
+ */
+async function openCreateTeam() {
+    try {
+        // Check for active season first
+        const seasonResponse = await fetch('/api/seasons/current');
+        const seasonData = await seasonResponse.json();
+
+        // Fetch games this user manages
+        const gamesResponse = await fetch('/api/teams/managed-games');
+        const gamesData = await gamesResponse.json();
+
+        if (!gamesData.success || !gamesData.games || gamesData.games.length === 0) {
+            alert('You are not assigned as Game Manager for any games.');
+            return;
+        }
+
+        if (gamesData.games.length === 1) {
+            // Only one game — go straight to team creation
+            const game = gamesData.games[0];
+            openCreateTeamModal(game.GameID, game.GameTitle, game.TeamSizes);
+        } else {
+            // Multiple games — show picker modal
+            openGamePickerModal(gamesData.games);
+        }
+    } catch (error) {
+        console.error('Error opening create team flow:', error);
+        alert('Failed to load game information. Please try again.');
+    }
+}
+
+/**
+ * Open game picker modal so a GM can choose which game to create a team for.
+ */
+function openGamePickerModal(games) {
+    // Remove any existing picker
+    const existingModal = document.getElementById('gamePickerModal');
+    if (existingModal) existingModal.remove();
+
+    const modal = document.createElement('div');
+    modal.id = 'gamePickerModal';
+    modal.className = 'modal';
+    modal.style.display = 'block';
+
+    const gameListHTML = games.map(game => {
+        const iconHTML = game.image_url
+            ? `<img src="${game.image_url}" alt="${game.GameTitle}"
+                    style="width:36px;height:36px;object-fit:cover;border-radius:8px;"
+                    onerror="this.style.display='none'">`
+            : `<i class="fas fa-gamepad" style="font-size:1.25rem;color:var(--stockton-blue);"></i>`;
+
+        return `
+            <button class="game-picker-option"
+                    onclick="closeGamePickerModal(); openCreateTeamModal(${game.GameID}, '${game.GameTitle.replace(/'/g, "\\'")}', '${game.TeamSizes}')">
+                <div class="game-picker-icon">${iconHTML}</div>
+                <div class="game-picker-info">
+                    <div class="game-picker-title">${game.GameTitle}</div>
+                    <div class="game-picker-division" style="font-size:0.8rem;color:var(--text-secondary);">${game.Division || ''}</div>
+                </div>
+                <i class="fas fa-chevron-right" style="color:var(--text-secondary);margin-left:auto;"></i>
+            </button>
+        `;
+    }).join('');
+
+    modal.innerHTML = `
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Select a Game</h2>
+                <button class="modal-close" onclick="closeGamePickerModal()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p class="modal-subtitle">Choose which game to create a team for</p>
+                <div class="game-picker-list">
+                    ${gameListHTML}
+                </div>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(modal);
+    document.body.style.overflow = 'hidden';
+}
+
+/**
+ * Close the game picker modal
+ */
+function closeGamePickerModal() {
+    const modal = document.getElementById('gamePickerModal');
+    if (modal) {
+        modal.remove();
+        document.body.style.overflow = 'auto';
+    }
+}
+
+// ============================================
 // EXPORT FUNCTIONS TO GLOBAL SCOPE
 // ============================================
 
@@ -1107,6 +1211,8 @@ window.hideDivisionFilterDropdown = hideDivisionFilterDropdown;
 window.handleDivisionFilterChange = handleDivisionFilterChange;
 window.invalidateTeamsCache = invalidateTeamsCache;
 window.isCacheFresh = isCacheFresh;
+window.openCreateTeam = openCreateTeam;
+window.closeGamePickerModal = closeGamePickerModal;
 
 //Past Season Exports
 window.initializePastSeasonFilter = initializePastSeasonFilter;

--- a/EsportsManagementTool/EsportsManagementTool/static/tournament-results.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/tournament-results.js
@@ -281,6 +281,9 @@ function displayRecordResultsModal(teams, season, placementOptions) {
     modalBody.appendChild(resultsContainer);
     modalBody.appendChild(notesSection);
     
+    // Character Counter
+    attachCharacterCounter('tournamentNotes', 250);
+
     // Modal footer
     const modalFooter = document.createElement('div');
     modalFooter.className = 'modal-footer';

--- a/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
@@ -44,6 +44,26 @@ function enableDropdown(dropdown) {
     dropdown.style.cursor = 'pointer';
 }
 
+/**
+ * Attach a live character counter to a text area.
+ */
+function attachCharacterCounter(textareaId, maxLength) {
+    const textarea = document.getElementById(textareaId);
+    if (!textarea) return;
+
+    textarea.setAttribute('maxlength', maxLength);
+
+    const counter = document.createElement('div');
+    counter.className = 'char-counter';
+    counter.textContent = `0 / ${maxLength}`;
+
+    textarea.parentNode.insertBefore(counter, textarea.nextSibling);
+
+    textarea.addEventListener('input', function() {
+        counter.textContent = `${textarea.value.length} / ${maxLength}`;
+    });
+}
+
 // ========================================
 // UTILITIES
 // =======================================

--- a/EsportsManagementTool/EsportsManagementTool/teams.py
+++ b/EsportsManagementTool/EsportsManagementTool/teams.py
@@ -672,7 +672,14 @@ def get_teams_for_sidebar():
 @app.route('/api/teams/sidebar-filters')
 @login_required
 def get_team_sidebar_filters():
-    """Get list of available view options based on user's roles"""
+    """
+    Get list of available view options based on user's roles.
+    Each role independently contributes its own views.
+    Admins: All Teams, Past Seasons, Division filters.
+    GMs: Managed Teams, Past Managed.
+    Players: My Teams, My Past Teams.
+    Any user associated with teams always sees the filter dropdown.
+    """
     cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
     try:
         perms = get_permissions_for_sidebar(session['id'])
@@ -681,20 +688,20 @@ def get_team_sidebar_filters():
         if perms['is_admin'] or perms['is_developer']:
             views.append({'value': 'all', 'label': 'All Teams', 'priority': 1})
 
-        if perms['manages_games']:
+        if perms['is_admin'] or perms['is_developer'] or perms['manages_games']:
             views.append({'value': 'manage', 'label': 'Managed Teams', 'priority': 2})
-            views.append({'value': 'past_managed', 'label': 'Old Managed Teams', 'priority': 3})
+            views.append({'value': 'past_managed', 'label': 'Past Managed Teams', 'priority': 3})
 
-        if perms['in_teams']:
+        if perms['is_player']:
             views.append({'value': 'play', 'label': 'My Teams', 'priority': 4})
-            views.append({'value': 'my_past_teams', 'label': 'My Old Teams', 'priority': 5})
+            views.append({'value': 'my_past_teams', 'label': 'My Past Teams', 'priority': 5})
 
         views.sort(key=lambda x: x['priority'])
 
         return jsonify({
             'success': True,
             'views': views,
-            'has_multiple': len(views) > 1
+            'has_multiple': len(views) > 0
         })
 
     except Exception as e:

--- a/EsportsManagementTool/EsportsManagementTool/teams.py
+++ b/EsportsManagementTool/EsportsManagementTool/teams.py
@@ -690,10 +690,14 @@ def get_team_sidebar_filters():
 
         if perms['is_admin'] or perms['is_developer'] or perms['manages_games']:
             views.append({'value': 'manage', 'label': 'Managed Teams', 'priority': 2})
+
+            if perms['is_admin'] or perms['is_developer'] or perms['manages_games'] or perms['has_managed_teams']:
             views.append({'value': 'past_managed', 'label': 'Past Managed Teams', 'priority': 3})
 
-        if perms['is_player']:
+        if perms['is_player'] or perms['in_teams']:
             views.append({'value': 'play', 'label': 'My Teams', 'priority': 4})
+
+        if perms['in_teams']:
             views.append({'value': 'my_past_teams', 'label': 'My Past Teams', 'priority': 5})
 
         views.sort(key=lambda x: x['priority'])
@@ -1106,6 +1110,7 @@ def get_permissions_for_sidebar(user_id):
     """
     Extends get_user_permissions with team/game membership checks
     needed to determine which sidebar views to show.
+    Checks past records directly so former GMs and players can still see their past teams.
     """
     perms = get_user_permissions(user_id)
 
@@ -1113,16 +1118,23 @@ def get_permissions_for_sidebar(user_id):
     try:
         manages_games = False
         in_teams = False
+        has_managed_teams = False
 
         if perms['is_admin'] or perms['is_developer'] or perms['is_gm']:
             cursor.execute("SELECT COUNT(*) as count FROM games WHERE gm_id = %s", (user_id,))
             manages_games = cursor.fetchone()['count'] > 0
 
-        if perms['is_player']:
-            cursor.execute("SELECT COUNT(*) as count FROM team_members WHERE user_id = %s", (user_id,))
-            in_teams = cursor.fetchone()['count'] > 0
+        cursor.execute("SELECT COUNT(*) as count FROM team_members WHERE user_id = %s", (user_id,))
+        in_teams = cursor.fetchone()['count'] > 0
 
-        return {**perms, 'manages_games': manages_games, 'in_teams': in_teams}
+        cursor.execute("""
+            SELECT COUNT(*) as count FROM teams t
+            JOIN games g ON t.gameID = g.GameID
+            WHERE g.gm_id = %s
+        """, (user_id,))
+        has_managed_teams = cursor.fetchone()['count'] > 0
+
+        return {**perms, 'manages_games': manages_games, 'in_teams': in_teams, 'has_managed_teams': has_managed_teams}
     finally:
         cursor.close()
 

--- a/EsportsManagementTool/EsportsManagementTool/teams.py
+++ b/EsportsManagementTool/EsportsManagementTool/teams.py
@@ -1043,6 +1043,55 @@ def delete_team():
         cursor.close()
 
 
+@app.route('/api/teams/managed-games', methods=['GET'])
+@login_required
+@roles_required('admin', 'gm', 'developer')
+def get_managed_games():
+    """
+    Return games the current user manages (is GM of).
+    Admins/developers get all games.
+    GMs get only their assigned games.
+    """
+    cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+    try:
+        perms = get_user_permissions(session['id'])
+
+        if perms['is_admin'] or perms['is_developer']:
+            cursor.execute("""
+                SELECT GameID, GameTitle, Abbreviation, TeamSizes, Division,
+                       CASE WHEN GameImage IS NOT NULL THEN 1 ELSE 0 END as has_image
+                FROM games
+                WHERE hidden = 0
+                ORDER BY GameTitle ASC
+            """)
+        else:
+            cursor.execute("""
+                SELECT GameID, GameTitle, Abbreviation, TeamSizes, Division,
+                       CASE WHEN GameImage IS NOT NULL THEN 1 ELSE 0 END as has_image
+                FROM games
+                WHERE gm_id = %s AND hidden = 0
+                ORDER BY GameTitle ASC
+            """, (session['id'],))
+
+        games = cursor.fetchall()
+
+        games_list = [{
+            'GameID':    g['GameID'],
+            'GameTitle': g['GameTitle'],
+            'TeamSizes': g['TeamSizes'],
+            'Division':  g['Division'],
+            'image_url': f'/game-image/{g["GameID"]}' if g['has_image'] else None
+        } for g in games]
+
+        return jsonify({'success': True, 'games': games_list})
+
+    except Exception as e:
+        print(f"Error fetching managed games: {e}")
+        return jsonify({'success': False, 'message': str(e)}), 500
+
+    finally:
+        cursor.close()
+
 # =====================================
 # HELPER FUNCTIONS
 # =====================================

--- a/EsportsManagementTool/EsportsManagementTool/teams.py
+++ b/EsportsManagementTool/EsportsManagementTool/teams.py
@@ -691,7 +691,7 @@ def get_team_sidebar_filters():
         if perms['is_admin'] or perms['is_developer'] or perms['manages_games']:
             views.append({'value': 'manage', 'label': 'Managed Teams', 'priority': 2})
 
-            if perms['is_admin'] or perms['is_developer'] or perms['manages_games'] or perms['has_managed_teams']:
+        if perms['is_admin'] or perms['is_developer'] or perms['manages_games'] or perms['has_managed_teams']:
             views.append({'value': 'past_managed', 'label': 'Past Managed Teams', 'priority': 3})
 
         if perms['is_player'] or perms['in_teams']:

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -963,7 +963,6 @@
                             <!-- Options populated dynamically by JavaScript -->
                         </select>
                     </div>
-                    <p class="teams-subtitle">Select a team to view details</p>
                 </div>
 
                 <!-- Loading State -->

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -949,12 +949,19 @@
                 <div class="teams-sidebar-header">
                     <div class="sidebar-header-top">
                         <h2>Teams</h2>
-                        <!-- View Switcher Dropdown (only visible for multi-role users) -->
-                        <div id="teamViewSwitcher" class="view-switcher hidden">
-                            <select id="teamViewSelect" class="view-switcher-select">
-                                <!-- Options populated dynamically by JavaScript -->
-                            </select>
-                        </div>
+                        {% if user.is_admin or user.is_developer or user.is_gm %}
+                        <button id="createTeamSidebarBtn"
+                                class="btn btn-primary btn-create-team-sidebar"
+                                onclick="openCreateTeam()">
+                            <i class="fas fa-plus"></i> Create Team
+                        </button>
+                        {% endif %}
+                    </div>
+                    <!-- View Switcher Dropdown moves below the header row -->
+                    <div id="teamViewSwitcher" class="view-switcher hidden">
+                        <select id="teamViewSelect" class="view-switcher-select">
+                            <!-- Options populated dynamically by JavaScript -->
+                        </select>
                     </div>
                     <p class="teams-subtitle">Select a team to view details</p>
                 </div>


### PR DESCRIPTION
Finished KAN-84, KAN-85, KAN-86, and KAN-101

Create Team Button migration
- Moved "Create Team" button from Communities tab game cards to Teams sidebar header
- Added "Create Team" button to sidebar header (visible to GM/admin/dev only)
- Moved view filter dropdown below sidebar header row
- Added game picker modal for GMs managing multiple games
- Added /api/teams/managed-games endpoint to fetch GM's assigned games
- Added CSS for sidebar Create Team button and game picker modal

Team Sidebar filters not appearing without multiple roles
- Filter dropdown now always visible to any user associated with teams
- Separated role-based view logic: 
  - Admins get All Teams/Past Seasons/Divisions 
  - GMs get Managed/Past Managed
  - Players get My Teams/My Past Teams
- Replaced has_multiple check with has_multiple: len(views) > 0 so single-view users still see the dropdown
- Moved team count from separate subtitle element into the filter dropdown label
- Removed teams-subtitle element from dashboard.html (so ui doesn't look clunky)

Teams Sidebar Filter fix
- Former GMs can now see past managed teams even if they are no longer assigned to a game / team
- Former players can now see 'My Teams' and 'My Past Teams' even if they no longer hold a player role
- Split view conditions into active and inactive checks so losing a role only removes access to current views, not previously joined ones.

Character counter display added below descriptions
- Added live character counter functionality for description fields.
- Update counter on each keystroke so users always see their current count.