### PR TITLE
Refactor team sidebar to tree layout and improve header UI

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.css
@@ -203,7 +203,7 @@
     top: calc(0.5rem + 38px);    /* row padding-top + full icon height */
     bottom: 0;
     width: 1px;
-    background: var(--border-color);
+    background:  rgba(121, 189, 233, 0.45);
     pointer-events: none;
 }
 

--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.css
@@ -4,597 +4,525 @@
    ORGANIZED BY CLAUDE AI
    ============================================ */
 
+
+.teams-layout {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: flex-start;
+    gap: 1.25rem;
+    width: 100%;
+}
+
+.teams-main-content {
+    flex: 1 1 0% !important;
+    min-width: 0;
+    overflow: hidden;
+}
+
 /* --------------------------------------------
    LEFT SIDEBAR - TEAM LIST
-   Fixed-width sidebar with team selection
    -------------------------------------------- */
 .teams-sidebar {
     background: var(--card-bg);
     border: 1px solid var(--border-color);
     border-radius: 12px;
-    padding: 1.5rem;
+    padding: 1.25rem 0;
     overflow-y: auto;
     overflow-x: hidden;
     display: flex;
     flex-direction: column;
-    width: 300px;
-    min-width: 300px;
-    max-width: 300px;
+    width: 280px;
+    min-width: 280px;
+    max-width: 280px;
     flex-shrink: 0;
+    align-self: stretch;
 }
 
-/* Sidebar header */
+/* ============================================
+   SIDEBAR HEADER
+   ============================================ */
 .teams-sidebar-header {
-    margin-bottom: 1.5rem;
+    padding: 0 1.25rem;
+    margin-bottom: 0.75rem;
 }
 
 .sidebar-header-top {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 0.5rem;
-    gap: 1rem;
+    margin-bottom: 0.25rem;
 }
 
 .sidebar-header-top h2 {
     margin: 0;
     font-size: 1.5rem;
+    font-weight: 700;
     color: var(--text-primary);
-    flex-shrink: 0;
+    letter-spacing: -0.01em;
 }
 
+/* + Create button — icon-only square button */
+.btn-create-team-sidebar {
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 7px;
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+    flex-shrink: 0;
+    line-height: 1;
+    letter-spacing: 0;
+}
+
+.btn-create-team-sidebar:hover {
+    background: var(--hover-bg);
+    border-color: var(--stockton-blue);
+    color: var(--stockton-blue);
+}
+
+.btn-create-team-sidebar i {
+    pointer-events: none;
+    display: block;
+}
+
+/* "All Games · N" subtitle */
 .teams-subtitle {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
     color: var(--text-secondary);
 }
 
-/* View switcher dropdown */
+/* ============================================
+   VIEW SWITCHER
+   ============================================ */
 .view-switcher {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    flex: 1;
-    min-width: 0;
+    padding: 0 1.25rem;
+    margin-bottom: 0.75rem;
 }
 
 .view-switcher-select {
     background: var(--dark-bg);
     border: 1px solid var(--border-color);
     border-radius: 6px;
-    color: var(--text-primary);
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.15s;
     width: 100%;
-    max-width: 180px;
     outline: none;
 }
 
-.view-switcher-select:hover {
-    border-color: var(--stockton-blue);
-    background: var(--hover-bg);
-}
-
+.view-switcher-select:hover,
 .view-switcher-select:focus {
     border-color: var(--stockton-blue);
-    box-shadow: 0 0 0 3px rgba(121, 189, 233, 0.1);
+    color: var(--text-primary);
 }
 
 .view-switcher-select option {
     background: var(--dark-bg);
     color: var(--text-primary);
-    padding: 0.5rem;
 }
 
 .view-switcher.hidden {
     display: none;
 }
 
-/* Sidebar states */
+/* ============================================
+   SIDEBAR STATES
+   ============================================ */
 .sidebar-loading,
 .sidebar-empty {
     text-align: center;
     padding: 2rem 1rem;
     color: var(--text-secondary);
+    font-size: 0.875rem;
 }
 
 .sidebar-loading i,
 .sidebar-empty i {
-    font-size: 2rem;
+    font-size: 1.75rem;
     margin-bottom: 0.5rem;
     color: var(--stockton-blue);
-}
-
-/* Teams list */
-.teams-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.team-sidebar-item {
-    padding: 0;
-    background: var(--dark-bg);
-    border: 2px solid var(--border-color);
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    position: relative;
-}
-
-.team-sidebar-content {
-    flex: 1;
-    padding: 1rem;
-    cursor: pointer;
-}
-
-.team-sidebar-item:hover {
-    background: var(--hover-bg);
-    border-color: var(--stockton-blue);
-    transform: translateX(4px);
-}
-
-.team-sidebar-item.active {
-    background: rgba(121, 189, 233, 0.1);
-    border-color: var(--stockton-blue);
-    border-left-width: 4px;
-}
-
-.team-sidebar-name {
-    font-weight: 600;
-    color: var(--text-primary);
-    margin-bottom: 0.25rem;
-    font-size: 0.9375rem;
-}
-
-.team-sidebar-game {
-    font-size: 0.8125rem;
-    color: var(--text-secondary);
-}
-
-.team-sidebar-meta {
-    display: flex;
-    gap: 1rem;
-    margin-top: 0.5rem;
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-}
-
-.team-sidebar-meta span {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-/* Edit button */
-.team-edit-btn {
-    background: transparent;
-    border: none;
-    color: var(--stockton-blue);
-    padding: 0.5rem 0.75rem;
-    cursor: pointer;
-    transition: all 0.2s;
-    font-size: 0.875rem;
-    margin-right: 0.5rem;
-    margin-top: 0.5rem;
-    border-radius: 6px;
-    opacity: 1;
-}
-
-.team-edit-btn:hover {
-    background: rgba(121, 189, 233, 0.15);
-    color: var(--stockton-blue);
-    transform: scale(1.1);
-}
-
-.team-edit-btn:active {
-    transform: scale(0.95);
+    display: block;
 }
 
 /* ============================================
-   DIVISION FILTER DROPDOWN - ADMIN ONLY
-   Additional filter for teams sidebar
+   TEAMS LIST CONTAINER
    ============================================ */
-
-/* Division filter container */
-.division-filter-container {
+.teams-list {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-    transition: all 0.3s ease;
+    flex-direction: column;
+    gap: 0;
 }
 
-.division-filter-container.hidden {
-    display: none;
-}
-
-/* Division filter label */
-.division-filter-label {
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--text-secondary);
-    margin: 0;
-    flex-shrink: 0;
-}
-
-/* Division filter select */
-.division-filter-select {
-    background: var(--dark-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    color: var(--text-primary);
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-    outline: none;
-    flex: 1;
-    min-width: 0;
-    max-width: 180px;
-}
-
-.division-filter-select:hover {
-    border-color: var(--stockton-blue);
-    background: var(--hover-bg);
-}
-
-.division-filter-select:focus {
-    border-color: var(--stockton-blue);
-    box-shadow: 0 0 0 3px rgba(121, 189, 233, 0.1);
-}
-
-.division-filter-select option {
-    background: var(--dark-bg);
-    color: var(--text-primary);
-    padding: 0.5rem;
-}
-
-/* Add icon to division options */
-.division-filter-select option[value="Strategy"]::before {
-    content: "♟ ";
-}
-
-.division-filter-select option[value="Shooter"]::before {
-    content: "⊕ ";
-}
-
-.division-filter-select option[value="Sports"]::before {
-    content: "⚽ ";
-}
-
-.division-filter-select option[value="Other"]::before {
-    content: "★ ";
-}
-
-/* --------------------------------------------
-   GAME GROUPING & COLLAPSIBLE FOLDERS
-   For "All Teams" view organization
-   -------------------------------------------- */
-
-/* Game group container */
+/* ============================================
+   GAME GROUP — collapsible folder
+   ============================================ */
 .game-group {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
 }
 
-/* Collapse/expand button on first team card */
-.team-collapse-btn {
-    position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
-    background: transparent;
-    border: 2px solid var(--border-color);
-    color: var(--text-secondary);
-    width: 28px;
-    height: 28px;
-    border-radius: 6px;
+/* ============================================
+   GAME ROW — clickable folder header
+   ============================================ */
+.game-folder-row {
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: 0.625rem;
+    padding: 0.5rem 1.25rem;
     cursor: pointer;
-    transition: all 0.2s ease;
-    z-index: 10;
-    padding: 0;
+    transition: background 0.12s;
+    user-select: none;
+    position: relative; /* needed for ::after drop line */
 }
 
-.team-collapse-btn:hover {
-    background: rgba(121, 189, 233, 0.15);
-    border-color: var(--stockton-blue);
-    color: var(--stockton-blue);
-    transform: scale(1.05);
+.game-folder-row:hover {
+    background: var(--hover-bg);
 }
 
-.team-collapse-btn:active {
-    transform: scale(0.95);
-}
-
-.team-collapse-btn i {
-    font-size: 0.75rem;
+/* Vertical drop from icon bottom-center down to the first team item.
+   Only visible when the group is expanded. */
+.game-group.expanded .game-folder-row::after {
+    content: '';
+    position: absolute;
+    left: calc(1.25rem + 19px);  /* icon center x */
+    top: calc(0.5rem + 38px);    /* row padding-top + full icon height */
+    bottom: 0;
+    width: 1px;
+    background: var(--border-color);
     pointer-events: none;
 }
 
-/* Collapsed game folder */
-.game-folder-collapsed {
-    background: var(--dark-bg);
-    border: 2px solid var(--border-color);
-    border-radius: 8px;
-    padding: 1rem;
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    position: relative;
-    min-width: 0;
-}
-
-.game-folder-collapsed:hover {
-    background: var(--hover-bg);
-    border-color: var(--stockton-blue);
-    transform: translateX(4px);
-}
-
-.game-folder-collapsed.active {
-    background: rgba(121, 189, 233, 0.1);
-    border-color: var(--stockton-blue);
-    border-left-width: 4px;
-}
-
-.game-folder-info {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-}
-
+/* Game icon */
 .game-folder-icon {
-    width: 36px;
-    height: 36px;
+    width: 38px;
+    height: 38px;
+    border-radius: 9px;
     background: linear-gradient(135deg, var(--stockton-blue), #1976D2);
-    border-radius: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: white;
-    font-size: 1rem;
+    color: #fff;
+    font-size: 0.9375rem;
     flex-shrink: 0;
     overflow: hidden;
     position: relative;
 }
 
-/* Ensure fallback icon is centered */
-.game-folder-icon > div {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(135deg, var(--stockton-blue), #1976D2);
-    border-radius: 8px;
+.game-folder-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 9px;
+    display: block;
 }
 
-.game-folder-details {
+.game-folder-icon .icon-fallback {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, var(--stockton-blue), #1976D2);
+    border-radius: 9px;
+}
+
+/* Game name */
+.game-folder-name {
     flex: 1;
     min-width: 0;
-    overflow: hidden;
-}
-
-.game-folder-name {
+    font-size: 0.9375rem;
     font-weight: 600;
     color: var(--text-primary);
-    font-size: 0.9375rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 100%;
 }
 
-.game-folder-count {
-    font-size: 0.75rem;
+/* Team count badge */
+.game-folder-badge {
+    min-width: 22px;
+    height: 22px;
+    border-radius: 11px;
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
     color: var(--text-secondary);
-    margin-top: 0.125rem;
-    white-space: nowrap;
-}
-
-.game-folder-expand-btn {
-    background: transparent;
-    border: 2px solid var(--border-color);
-    color: var(--text-secondary);
-    width: 28px;
-    height: 28px;
-    border-radius: 6px;
+    font-size: 0.6875rem;
+    font-weight: 600;
     display: flex;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
-    transition: all 0.2s ease;
+    padding: 0 5px;
     flex-shrink: 0;
-    margin-left: 0;
+    transition: background 0.12s, color 0.12s;
 }
 
-.game-folder-expand-btn:hover {
-    background: rgba(121, 189, 233, 0.15);
-    border-color: var(--stockton-blue);
+.game-folder-row:hover .game-folder-badge {
+    background: rgba(121, 189, 233, 0.12);
+    color: var(--stockton-blue);
+    border-color: rgba(121, 189, 233, 0.3);
+}
+
+/* Chevron — rotates when expanded */
+.game-folder-chevron {
+    font-size: 0.625rem;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+    transition: transform 0.2s ease, color 0.12s;
+}
+
+.game-group.expanded .game-folder-chevron {
+    transform: rotate(180deg);
     color: var(--stockton-blue);
 }
 
-.game-folder-expand-btn i {
-    font-size: 0.75rem;
+/* ============================================
+   TEAM LIST UNDER A GAME — tree style
+   ============================================ */
+.game-teams-list {
+    display: none;
+    flex-direction: column;
+    position: relative;
+    padding-bottom: 0.375rem;
 }
 
-/* Hide game groups when not in "all" or "division" or "past_seasons" view */
-.teams-sidebar:not([data-view="all"]):not([data-view="division"]):not([data-view="past_seasons"]) .game-group {
-    display: contents;
+.game-group.expanded .game-teams-list {
+    display: flex;
 }
 
-.teams-sidebar:not([data-view="all"]):not([data-view="division"]):not([data-view="past_seasons"]) .team-collapse-btn {
+/* Container ::before not used — line drawn on .game-folder-row::after */
+.game-teams-list::before {
     display: none;
 }
 
-/* --------------------------------------------
-   TEAM SIDEBAR SEASON INDICATOR
-   Shows season name in sidebar team cards
-   -------------------------------------------- */
-.team-sidebar-season {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-    margin-top: 0.25rem;
+/* ============================================
+   TEAM TREE ITEM
+   ============================================ */
+.team-tree-item {
+    position: relative;
+    /* indent = icon center (1.25rem + 19px) + 14px connector gap + inner padding */
+    padding: 0.3125rem 0.75rem 0.3125rem calc(1.25rem + 19px + 14px);
+    cursor: pointer;
+    border-radius: 0 6px 6px 0;
+    transition: background 0.12s;
     display: flex;
     align-items: center;
-    gap: 0.375rem;
-    font-style: italic;
+    gap: 0.5rem;
+    margin-right: 0.75rem;
 }
 
-.team-sidebar-season span {
-    font-size: 0.625rem;
+/* Default (middle items): full height vertical segment connecting items */
+.team-tree-item::before {
+    content: '';
+    position: absolute;
+    left: calc(1.25rem + 19px);
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: rgba(121, 189, 233, 0.45);
 }
 
-/* --------------------------------------------
-   PAST SEASON FILTER DROPDOWN
-   Similar to division filter, for admins/devs
-   -------------------------------------------- */
+/* First item: full height — top connects to icon drop, bottom to next item */
+.team-tree-item:first-child::before {
+    top: 0;
+    bottom: 0;
+}
+
+/* Last item: only top half — line stops at the item midpoint */
+.team-tree-item:last-child::before {
+    top: 0;
+    bottom: 50%;
+}
+
+/* Single item: top to midpoint only — connects to icon drop, no items below */
+.team-tree-item:only-child::before {
+    top: 0;
+    bottom: 50%;
+}
+
+/* Horizontal connector from vertical line to item text */
+.team-tree-item::after {
+    content: '';
+    position: absolute;
+    left: calc(1.25rem + 19px);
+    top: 50%;
+    width: 14px;
+    height: 1px;
+    background: rgba(121, 189, 233, 0.45);
+}
+
+.team-tree-item:hover {
+    background: var(--hover-bg);
+}
+
+/* Active state — blue left accent via box-shadow (::after is used for connector) */
+.team-tree-item.active {
+    background: rgba(121, 189, 233, 0.07);
+    box-shadow: inset 3px 0 0 var(--stockton-blue);
+}
+
+/* Team name */
+.team-tree-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+    transition: color 0.12s;
+}
+
+.team-tree-item:hover .team-tree-name {
+    color: var(--text-primary);
+}
+
+.team-tree-item.active .team-tree-name {
+    color: var(--stockton-blue);
+    font-weight: 600;
+}
+
+/* Edit button */
+.team-tree-edit-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    padding: 0.2rem 0.3rem;
+    cursor: pointer;
+    font-size: 0.75rem;
+    border-radius: 4px;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.12s, background 0.12s;
+    flex-shrink: 0;
+}
+
+.team-tree-item:hover .team-tree-edit-btn {
+    opacity: 1;
+}
+
+.team-tree-edit-btn:hover {
+    color: var(--stockton-blue);
+    background: rgba(121, 189, 233, 0.12);
+}
+
+/* ============================================
+   COMPATIBILITY SHIM
+   teams.js queries .team-sidebar-item and .team-sidebar-content.
+   These overrides ensure the tree layout is not broken by whatever
+   styles teams.css applies to those classes.
+   ============================================ */
+.team-tree-item.team-sidebar-item {
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 6px 6px 0 !important;
+    /* Use the tree indent, not the legacy sidebar padding */
+    padding: 0.3125rem 0.75rem 0.3125rem calc(1.25rem + 19px + 14px) !important;
+    margin: 0 0.75rem 0 0 !important;
+    transform: none !important;
+    flex-direction: row !important;
+}
+
+.team-tree-item.team-sidebar-item:hover {
+    background: var(--hover-bg) !important;
+    transform: none !important;
+}
+
+.team-tree-item.team-sidebar-item.active {
+    background: rgba(121, 189, 233, 0.07) !important;
+    border: none !important;
+    border-left: none !important;
+}
+
+.team-tree-item .team-sidebar-content.team-tree-content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 0;
+    background: none;
+}
+
+/* ============================================
+   PAST SEASON / DIVISION FILTER DROPDOWNS
+   ============================================ */
+.division-filter-container,
 .past-season-filter-container {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    padding: 0 1.25rem;
     margin-bottom: 0.75rem;
     transition: all 0.3s ease;
 }
 
+.division-filter-container.hidden,
 .past-season-filter-container.hidden {
     display: none;
 }
 
+.division-filter-label,
 .past-season-filter-label {
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     font-weight: 500;
     color: var(--text-secondary);
     margin: 0;
     flex-shrink: 0;
 }
 
+.division-filter-select,
 .past-season-filter-select {
     background: var(--dark-bg);
     border: 1px solid var(--border-color);
     border-radius: 6px;
     color: var(--text-primary);
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8125rem;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.15s;
     outline: none;
     flex: 1;
     min-width: 0;
-    max-width: 180px;
 }
 
-.past-season-filter-select:hover {
-    border-color: var(--stockton-blue);
-    background: var(--hover-bg);
-}
-
+.division-filter-select:hover,
+.division-filter-select:focus,
+.past-season-filter-select:hover,
 .past-season-filter-select:focus {
     border-color: var(--stockton-blue);
-    box-shadow: 0 0 0 3px rgba(121, 189, 233, 0.1);
+    box-shadow: 0 0 0 3px rgba(121, 189, 233, 0.08);
 }
 
+.division-filter-select option,
 .past-season-filter-select option {
     background: var(--dark-bg);
     color: var(--text-primary);
-    padding: 0.5rem;
 }
 
-/* Loading indicator for past season dropdown */
 #pastSeasonFilterLoadingIndicator {
     color: var(--stockton-blue);
     font-size: 0.875rem;
 }
 
-/* Animation for collapsing/expanding */
-.game-group-collapsing {
-    animation: collapseOut 0.3s ease-out forwards;
-}
-
-.game-group-expanding {
-    animation: expandIn 0.3s ease-out forwards;
-}
-
-@keyframes collapseOut {
-    from {
-        opacity: 1;
-        max-height: 1000px;
-    }
-    to {
-        opacity: 0;
-        max-height: 0;
-        margin: 0;
-        overflow: hidden;
-    }
-}
-
-@keyframes expandIn {
-    from {
-        opacity: 0;
-        max-height: 0;
-    }
-    to {
-        opacity: 1;
-        max-height: 1000px;
-    }
-}
-
-/* Animation for showing/hiding past season filter */
-@keyframes slideDownFilter {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-        max-height: 0;
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-        max-height: 100px;
-    }
-}
-
-.past-season-filter-container:not(.hidden) {
-    animation: slideDownFilter 0.3s ease-out;
-}
-
-/* Animation for showing/hiding Division filter */
-.division-filter-container:not(.hidden) {
-    animation: slideDownFilter 0.3s ease-out;
-}
-
-/* --------------------------------------------
-   CREATE TEAM & GAME PICKER 
-   Teams sidebar header button and game select
-   modal styles
-   -------------------------------------------- */
-
-/* Create Team button in sidebar header */
-.btn-create-team-sidebar {
-    padding: 0.4rem 0.75rem;
-    font-size: 0.8125rem;
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
-/* Game picker modal options */
+/* ============================================
+   GAME PICKER MODAL
+   ============================================ */
 .game-picker-list {
     display: flex;
     flex-direction: column;
@@ -635,62 +563,65 @@
     font-size: 0.9375rem;
 }
 
-/* --------------------------------------------
-   RESPONSIVE DESIGN
-   Mobile and tablet adaptations
-   -------------------------------------------- */
+/* ============================================
+   ANIMATIONS
+   ============================================ */
+@keyframes slideDownFilter {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.past-season-filter-container:not(.hidden),
+.division-filter-container:not(.hidden) {
+    animation: slideDownFilter 0.2s ease-out;
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
 @media (max-width: 1024px) {
+    .teams-layout {
+        flex-direction: column !important;
+    }
+
     .teams-sidebar {
         width: 100% !important;
         max-width: 100% !important;
         min-width: 0 !important;
-        max-height: 400px;
+        max-height: 360px;
+    }
+
+    .teams-main-content {
+        width: 100%;
     }
 }
 
 @media (max-width: 768px) {
     .sidebar-header-top {
-        flex-direction: column;
-        align-items: flex-start;
+        flex-direction: row;
+        align-items: center;
     }
 
-    .view-switcher {
-        width: 100%;
-    }
-
-    .view-switcher-select {
-        max-width: 100%;
-    }
-
-    .division-filter-container {
-        padding: 0.5rem;
-        gap: 0.375rem;
-    }
-
-    .division-filter-label {
-        font-size: 0.75rem;
-    }
-
-    .division-filter-select {
-        font-size: 0.8125rem;
-        padding: 0.4rem 0.6rem;
-    }
-
+    .view-switcher,
+    .division-filter-container,
     .past-season-filter-container {
-        padding: 0.5rem;
-        gap: 0.375rem;
+        padding: 0 1rem;
     }
 
-    .past-season-filter-label {
-        font-size: 0.75rem;
+    .game-folder-row {
+        padding: 0.5rem 1rem;
     }
 
-    .past-season-filter-select {
-        font-size: 0.8125rem;
-        padding: 0.4rem 0.6rem;
+    /* Adjust tree line and item indent for smaller sidebar padding */
+    .game-teams-list::before {
+        left: calc(1rem + 19px);
     }
 
-    .team-sidebar-season {
-        font-size: 0.6875rem;
+    .team-tree-item {
+        padding-left: calc(1rem + 19px + 14px);
+    }
+
+    .team-tree-item::before {
+        left: calc(1rem + 19px);
     }
 }

--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
@@ -8,7 +8,7 @@
  * - View switching (All Teams, Teams I Manage, Teams I Play On)
  * - Division filtering
  * - Team list rendering and filtering
- * - Game grouping with collapsible folders
+ * - Game grouping with collapsible tree folders
  * - Team selection from sidebar
  * - Sidebar state management
  * ============================================================================
@@ -72,7 +72,6 @@ const PastSeasonTeamsFilterState = {
 
 /**
  * Available views for current user based on permissions
- * Structure: [{ value: 'all', label: 'All Teams' }, ...]
  * @type {Array<Object>}
  */
 window.availableViews = [];
@@ -85,25 +84,21 @@ window.currentView = null;
 
 /**
  * Session storage key for view persistence
- * @type {string}
  */
 const VIEW_STORAGE_KEY = 'teams_selected_view';
 
 /**
- * Storage key for collapsed games
- * @type {string}
+ * Storage key for expanded games
  */
 const COLLAPSED_GAMES_KEY = 'teams_expanded_games';
 
 /**
  * Division filter storage key
- * @type {string}
  */
 const DIVISION_FILTER_KEY = 'teams_selected_division';
 
 /**
  * Division order configuration
- * @type {Array<string>}
  */
 const DIVISION_ORDER = ['Strategy', 'Shooter', 'Sports', 'Other'];
 
@@ -111,10 +106,6 @@ const DIVISION_ORDER = ['Strategy', 'Shooter', 'Sports', 'Other'];
 // VIEW SWITCHER INITIALIZATION
 // ============================================
 
-/**
- * Initialize view switcher on page load
- * Fetches available views based on user permissions and sets up UI
- */
 async function initializeViewSwitcher() {
     try {
         const response = await fetch('/api/teams/sidebar-filters');
@@ -127,9 +118,7 @@ async function initializeViewSwitcher() {
             const validStoredView = window.availableViews.find(v => v.value === storedView);
             window.currentView = validStoredView ? storedView : window.availableViews[0].value;
 
-            // Always render — any user associated with teams sees the dropdown
             renderViewSwitcher();
-
             initializeDivisionFilter();
             initializePastSeasonFilter();
         } else {
@@ -141,9 +130,6 @@ async function initializeViewSwitcher() {
     }
 }
 
-/**
- * Render the view switcher dropdown
- */
 function renderViewSwitcher() {
     const viewSwitcher = document.getElementById('teamViewSwitcher');
     const viewSelect = document.getElementById('teamViewSelect');
@@ -160,9 +146,7 @@ function renderViewSwitcher() {
         option.value = view.value;
         option.textContent = view.label;
         option.setAttribute('data-base-label', view.label);
-        if (view.value === window.currentView) {
-            option.selected = true;
-        }
+        if (view.value === window.currentView) option.selected = true;
         viewSelect.appendChild(option);
     });
 
@@ -188,19 +172,11 @@ function renderViewSwitcher() {
     viewSelect.onchange = handleViewChange;
 }
 
-/**
- * Hide the view switcher
- */
 function hideViewSwitcher() {
     const viewSwitcher = document.getElementById('teamViewSwitcher');
-    if (viewSwitcher) {
-        viewSwitcher.classList.add('hidden');
-    }
+    if (viewSwitcher) viewSwitcher.classList.add('hidden');
 }
 
-/**
- * Handle view change from dropdown
- */
 function handleViewChange(event) {
     const newView = event.target.value;
 
@@ -208,39 +184,30 @@ function handleViewChange(event) {
         window.currentView = newView;
         sessionStorage.setItem(VIEW_STORAGE_KEY, newView);
 
-        // Hide all secondary filters first
         hideDivisionFilterDropdown();
         hidePastSeasonFilterDropdown();
 
-        // Reset filter states
         setSelectedDivisionFilter(null);
 
-        // IMPORTANT: Reset past season filter completely
         PastSeasonTeamsFilterState.selectedSeasonId = null;
         PastSeasonTeamsFilterState.selectedSeasonName = '';
         PastSeasonTeamsFilterState.isFilteringPastSeason = false;
-        setSelectedPastSeasonFilter(null); // Clear from session storage
+        setSelectedPastSeasonFilter(null);
 
-        // Reset the dropdown value if it exists
         const seasonSelect = document.getElementById('pastSeasonFilterSelect');
-        if (seasonSelect) {
-            seasonSelect.value = '';
-        }
+        if (seasonSelect) seasonSelect.value = '';
 
-        // CRITICAL: Invalidate all cache when switching views to force fresh data load
         invalidateTeamsCache();
 
-        // Show appropriate filter
         if (newView === 'division') {
             showDivisionFilterDropdown();
         } else if (newView === 'past_seasons') {
             PastSeasonTeamsFilterState.isFilteringPastSeason = true;
             showPastSeasonFilterDropdown();
             loadPastSeasonsForTeamsFilter();
-            return; // Don't load teams yet, wait for season selection
+            return;
         }
 
-        // Reset team selection and show welcome state
         window.currentSelectedTeamId = null;
         document.getElementById('teamsWelcomeState').style.display = 'flex';
         document.getElementById('teamsDetailContent').style.display = 'none';
@@ -253,9 +220,6 @@ function handleViewChange(event) {
 // TEAM LOADING & SIDEBAR
 // ============================================
 
-/**
- * Load teams based on user role and selected view
- */
 async function loadTeams() {
     const sidebarLoading = document.getElementById('teamsSidebarLoading');
     const sidebarList = document.getElementById('teamsSidebarList');
@@ -265,7 +229,6 @@ async function loadTeams() {
         await initializeViewSwitcher();
     }
 
-    // Generate cache key
     const selectedDivision = window.currentView === 'division' ? getSelectedDivisionFilter() : null;
     const selectedSeasonId = window.currentView === 'past_seasons' ? PastSeasonTeamsFilterState.selectedSeasonId : null;
 
@@ -276,37 +239,29 @@ async function loadTeams() {
         cacheKey = `past_season-${selectedSeasonId}`;
     }
 
-    // IMPORTANT: If in past_seasons view but no season selected, show empty state immediately
     if (window.currentView === 'past_seasons' && !selectedSeasonId) {
         sidebarLoading.style.display = 'none';
         sidebarList.style.display = 'none';
         sidebarEmpty.style.display = 'block';
-
         updateDropdownCount(0);
-
         if (sidebarEmpty) {
             sidebarEmpty.innerHTML = `<i class="fas fa-calendar"></i><p>Select a past season to view teams</p>`;
         }
         return;
     }
 
-    // Check cache first
     if (teamsCache[cacheKey] && isCacheFresh(cacheKey)) {
         console.log('Using cached teams data');
         renderFromCache(teamsCache[cacheKey], sidebarLoading, sidebarList, sidebarEmpty);
         return;
     }
 
-    // Show loading state
     sidebarLoading.style.display = 'block';
     sidebarList.style.display = 'none';
     sidebarEmpty.style.display = 'none';
 
     try {
-        // Build URL with parameters
         let url = `/api/teams/sidebar?view=${window.currentView}`;
-
-        // Add season parameter if filtering past seasons
         if (selectedSeasonId) url += `&season_id=${selectedSeasonId}`;
 
         const response = await fetch(url);
@@ -315,7 +270,6 @@ async function loadTeams() {
         if (data.success && data.teams && data.teams.length > 0) {
             let teamsToDisplay = data.teams;
 
-            // Apply division filter if active
             if (window.currentView === 'division') {
                 const selectedDivision = getSelectedDivisionFilter();
                 if (selectedDivision) {
@@ -325,13 +279,12 @@ async function loadTeams() {
                 }
             }
 
-            // Cache the data
             teamsCache[cacheKey] = teamsToDisplay;
             teamsCache.timestamps[cacheKey] = Date.now();
-
             window.allTeamsData = teamsToDisplay;
 
             updateDropdownCount(teamsToDisplay.length);
+            updateSidebarSubtitle(teamsToDisplay.length);
 
             if (teamsToDisplay.length > 0) {
                 renderTeamsSidebar(teamsToDisplay);
@@ -347,6 +300,7 @@ async function loadTeams() {
             }
         } else {
             updateDropdownCount(0);
+            updateSidebarSubtitle(0);
             if (sidebarEmpty) {
                 sidebarEmpty.innerHTML = `<i class="fas fa-users"></i><p>${getEmptyMessageForView(window.currentView)}</p>`;
             }
@@ -360,13 +314,10 @@ async function loadTeams() {
     }
 }
 
-/**
- * Helper function to render from cached data
- */
 function renderFromCache(cachedTeams, sidebarLoading, sidebarList, sidebarEmpty) {
     window.allTeamsData = cachedTeams;
-
     updateDropdownCount(cachedTeams.length);
+    updateSidebarSubtitle(cachedTeams.length);
 
     if (cachedTeams.length > 0) {
         renderTeamsSidebar(cachedTeams);
@@ -382,9 +333,6 @@ function renderFromCache(cachedTeams, sidebarLoading, sidebarList, sidebarEmpty)
     }
 }
 
-/**
- * Function to invalidate cache when teams are modified
- */
 function invalidateTeamsCache() {
     teamsCache.all = null;
     teamsCache.manage = null;
@@ -398,50 +346,51 @@ function invalidateTeamsCache() {
 }
 
 /**
- * Get subtitle text based on current view
+ * Update the "All Games · N" subtitle in the sidebar header
  */
+function updateSidebarSubtitle(count) {
+    const subtitle = document.querySelector('.teams-subtitle');
+    if (!subtitle) return;
+
+    const view = window.currentView;
+    let label = 'All Games';
+
+    if (view === 'manage' || view === 'past_managed') {
+        label = 'Managed Games';
+    } else if (view === 'play' || view === 'my_past_teams') {
+        label = 'My Games';
+    } else if (view === 'division') {
+        const d = getSelectedDivisionFilter();
+        label = d ? `${d} Division` : 'All Divisions';
+    } else if (view === 'past_seasons') {
+        const name = PastSeasonTeamsFilterState.selectedSeasonName;
+        label = name ? name : 'Past Seasons';
+    }
+
+    subtitle.textContent = `${label} · ${count}`;
+}
+
 function getSubtitleForView(view, count = 0) {
     let label = '';
-
     if (view === 'division') {
         const selectedDivision = getSelectedDivisionFilter();
-        if (selectedDivision) {
-            label = `${selectedDivision} Teams`;
-        } else {
-            label = 'All Teams';
-        }
+        label = selectedDivision ? `${selectedDivision} Teams` : 'All Teams';
     } else if (view === 'past_seasons') {
         const seasonName = PastSeasonTeamsFilterState.selectedSeasonName;
-        if (seasonName) {
-            label = `${seasonName} Teams`;
-        } else {
-            label = 'Past Seasons';
-        }
+        label = seasonName ? `${seasonName} Teams` : 'Past Seasons';
     } else {
         const viewObj = window.availableViews.find(v => v.value === view);
-
         if (viewObj) {
             label = viewObj.label;
         } else {
-            const isAdmin = window.userPermissions?.is_admin || window.userPermissions.is_developer || false;
+            const isAdmin = window.userPermissions?.is_admin || window.userPermissions?.is_developer || false;
             const isGM = window.userPermissions?.is_gm || false;
-
-            if (isAdmin) {
-                label = 'All Teams';
-            } else if (isGM) {
-                label = 'Teams I Manage';
-            } else {
-                label = 'Your Teams';
-            }
+            label = isAdmin ? 'All Teams' : isGM ? 'Teams I Manage' : 'Your Teams';
         }
     }
-
     return `${label} (${count})`;
 }
 
-/**
- * Get empty state message based on current view
- */
 function getEmptyMessageForView(view) {
     const messages = {
         all: 'No teams have been created yet.',
@@ -451,59 +400,312 @@ function getEmptyMessageForView(view) {
         past_managed: 'You have not managed any past teams.',
         past_seasons: 'No teams found for the selected season.'
     };
-
     return messages[view] || 'No teams available.';
 }
 
+// ============================================
+// TREE-STYLE SIDEBAR RENDERING
+// ============================================
+
 /**
- * Render teams in sidebar (basic version)
+ * Main render entry point — delegates to tree or flat based on view
  */
 function renderTeamsSidebar(teams) {
+    if (
+        window.currentView === 'all' ||
+        window.currentView === 'division' ||
+        window.currentView === 'past_seasons'
+    ) {
+        renderTeamsSidebarWithGroups(teams);
+    } else {
+        renderTeamsSidebarFlat(teams);
+    }
+}
+
+/**
+ * Render teams in a flat list (for manage / play / my_past_teams / past_managed views)
+ */
+function renderTeamsSidebarFlat(teams) {
     const sidebarList = document.getElementById('teamsSidebarList');
     sidebarList.innerHTML = '';
 
-    teams.forEach(team => {
-        const teamItem = document.createElement('div');
-        teamItem.className = 'team-sidebar-item';
-        teamItem.setAttribute('data-team-id', team.TeamID);
-        teamItem.setAttribute('data-gm-id', team.gm_id || '');
+    const sidebar = document.querySelector('.teams-sidebar');
+    if (sidebar) sidebar.setAttribute('data-view', window.currentView || 'all');
 
-        const isGameManager = team.gm_id && team.gm_id === window.currentUserId;
+    const sorted = sortTeamsByDivision(teams);
 
-        // Season indicator - ONLY show for PAST teams (season_is_active = 0)
-        const seasonIndicator = (team.season_name && team.season_is_active === 0) ? `
-            <div class="team-sidebar-season" title="Past Season">
-                <span style="color: #94a3b8;">●</span>
-                ${team.season_name}
-            </div>
-        ` : '';
-
-        teamItem.innerHTML = `
-            <div class="team-sidebar-content" onclick="selectTeam('${team.TeamID}')">
-                <div class="team-sidebar-name">${team.teamName}</div>
-                ${seasonIndicator}
-                <div class="team-sidebar-game">${team.GameTitle || 'Unknown Game'}</div>
-                <div class="team-sidebar-meta">
-                    <span><i class="fas fa-users"></i> ${team.member_count || 0}</span>
-                    <span><i class="fas fa-trophy"></i> ${team.teamMaxSize}</span>
-                </div>
-            </div>
-            ${isGameManager && team.season_is_active !== 0 ? `
-                <button class="team-edit-btn"
-                        onclick="event.stopPropagation(); openEditTeamModal('${team.TeamID}', '${team.teamName.replace(/'/g, "\\'")}', ${team.teamMaxSize}, '${team.TeamSizes || ''}')"
-                        title="Edit team">
-                    <i class="fas fa-edit"></i>
-                </button>
-            ` : ''}
-        `;
-
-        sidebarList.appendChild(teamItem);
+    sorted.forEach(team => {
+        const item = createTeamTreeItem(team);
+        sidebarList.appendChild(item);
     });
 }
 
 /**
- * Update the currently selected dropdown option to show the team count.
+ * Render teams grouped by game in tree/folder style
  */
+function renderTeamsSidebarWithGroups(teams) {
+    const sidebarList = document.getElementById('teamsSidebarList');
+    sidebarList.innerHTML = '';
+
+    const sidebar = document.querySelector('.teams-sidebar');
+    if (sidebar) sidebar.setAttribute('data-view', window.currentView || 'all');
+
+    const sorted = sortTeamsByDivision(teams);
+
+    // Build game groups
+    const gameGroups = {};
+    sorted.forEach(team => {
+        const gameId = team.gameID;
+        if (!gameGroups[gameId]) {
+            gameGroups[gameId] = {
+                gameId,
+                gameTitle:    team.GameTitle || 'Unknown Game',
+                division:     team.division || 'Other',
+                hasGameImage: team.has_game_image,
+                teams:        []
+            };
+        }
+        gameGroups[gameId].teams.push(team);
+    });
+
+    // Sort groups by division then name
+    const sortedGroups = Object.values(gameGroups).sort((a, b) => {
+        const pa = getDivisionSortPriority(a.division);
+        const pb = getDivisionSortPriority(b.division);
+        if (pa !== pb) return pa - pb;
+        return a.gameTitle.localeCompare(b.gameTitle);
+    });
+
+    const expandedGames = getCollapsedGames(); // set of expanded game IDs
+
+    sortedGroups.forEach(group => {
+        const isExpanded = expandedGames.has(group.gameId.toString());
+        const groupEl = renderGameGroup(group, isExpanded);
+        sidebarList.appendChild(groupEl);
+    });
+}
+
+/**
+ * Build a full game group element (folder row + team list)
+ */
+function renderGameGroup(group, isExpanded) {
+    const groupDiv = document.createElement('div');
+    groupDiv.className = 'game-group' + (isExpanded ? ' expanded' : '');
+    groupDiv.setAttribute('data-game-id', group.gameId);
+
+    // ---- Game folder row ----
+    const folderRow = document.createElement('div');
+    folderRow.className = 'game-folder-row';
+
+    // Icon
+    const iconEl = document.createElement('div');
+    iconEl.className = 'game-folder-icon';
+
+    if (group.gameId && group.hasGameImage) {
+        const img = document.createElement('img');
+        img.src = `/game-image/${group.gameId}`;
+        img.alt = group.gameTitle;
+        img.loading = 'lazy';
+
+        const fallback = document.createElement('div');
+        fallback.className = 'icon-fallback';
+        fallback.innerHTML = '<i class="fas fa-gamepad"></i>';
+        fallback.style.display = 'none';
+
+        img.onerror = function () {
+            this.style.display = 'none';
+            fallback.style.display = 'flex';
+        };
+
+        iconEl.appendChild(img);
+        iconEl.appendChild(fallback);
+    } else {
+        const fallback = document.createElement('div');
+        fallback.className = 'icon-fallback';
+        fallback.innerHTML = '<i class="fas fa-gamepad"></i>';
+        iconEl.appendChild(fallback);
+    }
+
+    // Game name
+    const nameEl = document.createElement('span');
+    nameEl.className = 'game-folder-name';
+    nameEl.textContent = group.gameTitle;
+
+    // Badge (team count)
+    const badgeEl = document.createElement('span');
+    badgeEl.className = 'game-folder-badge';
+    badgeEl.textContent = group.teams.length;
+
+    // Chevron
+    const chevronEl = document.createElement('i');
+    chevronEl.className = 'game-folder-chevron fas fa-chevron-down';
+
+    folderRow.appendChild(iconEl);
+    folderRow.appendChild(nameEl);
+    folderRow.appendChild(badgeEl);
+    folderRow.appendChild(chevronEl);
+
+    // Click toggles expand/collapse
+    folderRow.addEventListener('click', () => toggleGameCollapse(group.gameId));
+
+    // ---- Teams list ----
+    const teamsList = document.createElement('div');
+    teamsList.className = 'game-teams-list';
+
+    group.teams.forEach(team => {
+        const item = createTeamTreeItem(team);
+        teamsList.appendChild(item);
+    });
+
+    groupDiv.appendChild(folderRow);
+    groupDiv.appendChild(teamsList);
+
+    return groupDiv;
+}
+
+/**
+ * Create a single team tree item.
+ * Carries .team-sidebar-item so teams.js querySelector calls still work.
+ */
+function createTeamTreeItem(team) {
+    const item = document.createElement('div');
+    // Keep legacy class so teams.js selectTeam/querySelector still finds items
+    item.className = 'team-tree-item team-sidebar-item';
+    item.setAttribute('data-team-id', team.TeamID);
+    item.setAttribute('data-gm-id', team.gm_id || '');
+
+    if (String(team.TeamID) === String(window.currentSelectedTeamId)) {
+        item.classList.add('active');
+    }
+
+    const isGameManager = team.gm_id && String(team.gm_id) === String(window.currentUserId);
+
+    // Season indicator for past teams
+    const seasonText = (team.season_name && team.season_is_active === 0)
+        ? ' · ' + team.season_name
+        : '';
+
+    // Wrap in .team-sidebar-content so any teams.js inner queries work
+    const contentWrapper = document.createElement('div');
+    contentWrapper.className = 'team-sidebar-content team-tree-content';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'team-tree-name';
+    nameEl.textContent = team.teamName + seasonText;
+
+    contentWrapper.appendChild(nameEl);
+    item.appendChild(contentWrapper);
+
+    // Edit button — only for GMs on active seasons
+    if (isGameManager && team.season_is_active !== 0) {
+        const editBtn = document.createElement('button');
+        editBtn.className = 'team-tree-edit-btn';
+        editBtn.title = 'Edit team';
+        editBtn.innerHTML = '<i class="fas fa-pencil-alt"></i>';
+        editBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            openEditTeamModal(
+                team.TeamID,
+                team.teamName,
+                team.teamMaxSize,
+                team.TeamSizes || ''
+            );
+        });
+        item.appendChild(editBtn);
+    }
+
+    // Select team on click (on item or content wrapper)
+    item.addEventListener('click', () => selectTeam(team.TeamID));
+
+    return item;
+}
+
+// ============================================
+// COLLAPSE / EXPAND STATE
+// ============================================
+
+/**
+ * Get set of expanded game IDs from sessionStorage
+ */
+function getCollapsedGames() {
+    const storageKey = `${COLLAPSED_GAMES_KEY}_${window.currentView || 'all'}`;
+    const stored = sessionStorage.getItem(storageKey);
+    return stored ? new Set(JSON.parse(stored)) : new Set();
+}
+
+function saveCollapsedGames(expandedGames) {
+    const storageKey = `${COLLAPSED_GAMES_KEY}_${window.currentView || 'all'}`;
+    sessionStorage.setItem(storageKey, JSON.stringify([...expandedGames]));
+}
+
+/**
+ * Toggle collapse/expand for a game group in the DOM (no full re-render)
+ */
+function toggleGameCollapse(gameId) {
+    const expandedGames = getCollapsedGames();
+    const key = gameId.toString();
+
+    if (expandedGames.has(key)) {
+        expandedGames.delete(key);
+    } else {
+        expandedGames.add(key);
+    }
+
+    saveCollapsedGames(expandedGames);
+
+    // Toggle the .expanded class directly on the DOM element
+    const groupEl = document.querySelector(`.game-group[data-game-id="${gameId}"]`);
+    if (groupEl) {
+        groupEl.classList.toggle('expanded', expandedGames.has(key));
+    }
+}
+
+// ============================================
+// ACTIVE TEAM HIGHLIGHT
+// ============================================
+
+/**
+ * Update active state on sidebar items without re-rendering.
+ * Covers both new tree items and any legacy .team-sidebar-item elements
+ * that teams.js may also query.
+ */
+function updateSidebarActiveState(teamId) {
+    const id = String(teamId);
+    document.querySelectorAll(
+        '.team-tree-item, .team-sidebar-item'
+    ).forEach(el => {
+        el.classList.toggle('active', el.getAttribute('data-team-id') === id);
+    });
+}
+
+// ============================================
+// DIVISION & SORT HELPERS
+// ============================================
+
+function getDivisionSortPriority(division) {
+    const index = DIVISION_ORDER.indexOf(division);
+    return index !== -1 ? index : 999;
+}
+
+function sortTeamsByDivision(teams) {
+    return [...teams].sort((a, b) => {
+        const divA = getDivisionSortPriority(a.division || 'Other');
+        const divB = getDivisionSortPriority(b.division || 'Other');
+        if (divA !== divB) return divA - divB;
+
+        const gameA = (a.GameTitle || '').toLowerCase();
+        const gameB = (b.GameTitle || '').toLowerCase();
+        if (gameA !== gameB) return gameA.localeCompare(gameB);
+
+        if (a.created_at && b.created_at) return new Date(a.created_at) - new Date(b.created_at);
+        return 0;
+    });
+}
+
+// ============================================
+// DROPDOWN COUNT
+// ============================================
+
 function updateDropdownCount(count) {
     const viewSelect = document.getElementById('teamViewSelect');
     if (!viewSelect) return;
@@ -519,98 +721,13 @@ function updateDropdownCount(count) {
 }
 
 // ============================================
-// GAME GROUPING & COLLAPSIBLE FOLDERS
-// ============================================
-
-/**
- * Get set of expanded game IDs from sessionStorage. Not renaming because gross.
- */
-function getCollapsedGames() {
-    const storageKey = `${COLLAPSED_GAMES_KEY}_${window.currentView || 'all'}`;
-    const stored = sessionStorage.getItem(storageKey);
-    return stored ? new Set(JSON.parse(stored)) : new Set();
-}
-
-/**
- * Save collapsed games to sessionStorage
- */
-function saveCollapsedGames(collapsedGames) {
-    const storageKey = `${COLLAPSED_GAMES_KEY}_${window.currentView || 'all'}`;
-    sessionStorage.setItem(storageKey, JSON.stringify([...collapsedGames]));
-}
-
-/**
- * Toggle collapse state for a game
- */
-function toggleGameCollapse(gameId) {
-    const collapsedGames = getCollapsedGames();
-
-    if (collapsedGames.has(gameId)) {
-        collapsedGames.delete(gameId);
-    } else {
-        collapsedGames.add(gameId);
-    }
-
-    saveCollapsedGames(collapsedGames);
-
-    const sidebarList = document.getElementById('teamsSidebarList');
-    if (sidebarList && window.allTeamsData.length > 0) {
-        renderTeamsSidebarWithGroups(window.allTeamsData);
-    }
-}
-
-/**
- * Get sort priority for a division
- */
-function getDivisionSortPriority(division) {
-    const index = DIVISION_ORDER.indexOf(division);
-    return index !== -1 ? index : 999;
-}
-
-/**
- * Sort teams by division order, then alphabetically by game title
- */
-function sortTeamsByDivision(teams) {
-    return teams.sort((a, b) => {
-        const divisionA = a.division || 'Other';
-        const divisionB = b.division || 'Other';
-
-        const priorityA = getDivisionSortPriority(divisionA);
-        const priorityB = getDivisionSortPriority(divisionB);
-
-        if (priorityA !== priorityB) {
-            return priorityA - priorityB;
-        }
-
-        const gameA = (a.GameTitle || '').toLowerCase();
-        const gameB = (b.GameTitle || '').toLowerCase();
-
-        if (gameA !== gameB) {
-            return gameA.localeCompare(gameB);
-        }
-
-        if (a.created_at && b.created_at) {
-            return new Date(a.created_at) - new Date(b.created_at);
-        }
-
-        return 0;
-    });
-}
-
-// ============================================
 // PAST SEASON FILTER
 // ============================================
 
-/**
- * Get currently selected past season filter
- */
 function getSelectedPastSeasonFilter() {
     return sessionStorage.getItem(PAST_SEASON_FILTER_KEY);
 }
 
-/**
- * Set past season filter
- */
 function setSelectedPastSeasonFilter(seasonId) {
     if (seasonId) {
         sessionStorage.setItem(PAST_SEASON_FILTER_KEY, seasonId);
@@ -619,11 +736,8 @@ function setSelectedPastSeasonFilter(seasonId) {
     }
 }
 
-/**
- * Initialize past season filter dropdown
- */
 function initializePastSeasonFilter() {
-    const isAdmin = window.userPermissions?.is_admin || window.userPermissions.is_developer || false;
+    const isAdmin = window.userPermissions?.is_admin || window.userPermissions?.is_developer || false;
     if (!isAdmin) return;
 
     const divisionFilterContainer = document.getElementById('divisionFilterContainer');
@@ -637,9 +751,7 @@ function initializePastSeasonFilter() {
         pastSeasonFilterContainer.className = 'past-season-filter-container hidden';
 
         pastSeasonFilterContainer.innerHTML = `
-            <label for="pastSeasonFilterSelect" class="past-season-filter-label">
-                Season:
-            </label>
+            <label for="pastSeasonFilterSelect" class="past-season-filter-label">Season:</label>
             <select id="pastSeasonFilterSelect" class="past-season-filter-select">
                 <option value="">Select Past Season</option>
             </select>
@@ -666,43 +778,26 @@ function initializePastSeasonFilter() {
         if (savedSeasonId) {
             PastSeasonTeamsFilterState.selectedSeasonId = savedSeasonId;
             const seasonSelect = document.getElementById('pastSeasonFilterSelect');
-            if (seasonSelect) {
-                seasonSelect.value = savedSeasonId;
-            }
+            if (seasonSelect) seasonSelect.value = savedSeasonId;
         }
     }
 }
 
-/**
- * Show past season filter dropdown
- */
 function showPastSeasonFilterDropdown() {
     const container = document.getElementById('pastSeasonFilterContainer');
-    if (container) {
-        container.classList.remove('hidden');
-    }
+    if (container) container.classList.remove('hidden');
 }
 
-/**
- * Hide past season filter dropdown
- */
 function hidePastSeasonFilterDropdown() {
     const container = document.getElementById('pastSeasonFilterContainer');
-    if (container) {
-        container.classList.add('hidden');
-    }
+    if (container) container.classList.add('hidden');
 }
 
-/**
- * Load past seasons for teams filter
- */
 async function loadPastSeasonsForTeamsFilter() {
     const seasonSelect = document.getElementById('pastSeasonFilterSelect');
     const loadingIndicator = document.getElementById('pastSeasonFilterLoadingIndicator');
-
     if (!seasonSelect) return;
 
-    // Show loading
     if (loadingIndicator) loadingIndicator.style.display = 'inline-block';
     seasonSelect.disabled = true;
 
@@ -712,8 +807,6 @@ async function loadPastSeasonsForTeamsFilter() {
 
         if (data.success && data.seasons) {
             PastSeasonTeamsFilterState.availablePastSeasons = data.seasons;
-
-            // Clear and populate dropdown
             seasonSelect.innerHTML = '<option value="">Select Past Season</option>';
 
             if (data.seasons.length === 0) {
@@ -727,7 +820,6 @@ async function loadPastSeasonsForTeamsFilter() {
                 });
             }
         } else {
-            console.error('Failed to load past seasons:', data.message);
             seasonSelect.innerHTML = '<option value="">Error loading past seasons</option>';
         }
     } catch (error) {
@@ -739,9 +831,6 @@ async function loadPastSeasonsForTeamsFilter() {
     }
 }
 
-/**
- * Handle past season filter change
- */
 function handlePastSeasonFilterChange(event) {
     const selectedSeasonId = event.target.value;
 
@@ -752,226 +841,28 @@ function handlePastSeasonFilterChange(event) {
         return;
     }
 
-    // Store selected past season
     PastSeasonTeamsFilterState.selectedSeasonId = selectedSeasonId;
     const seasonSelect = event.target;
     PastSeasonTeamsFilterState.selectedSeasonName = seasonSelect.options[seasonSelect.selectedIndex].text;
     setSelectedPastSeasonFilter(selectedSeasonId);
 
-    // Invalidate cache to ensure fresh data for the selected season
     invalidateTeamsCache();
 
-    // Reset team selection
     window.currentSelectedTeamId = null;
     document.getElementById('teamsWelcomeState').style.display = 'flex';
     document.getElementById('teamsDetailContent').style.display = 'none';
 
-    // Load teams for this past season
     loadTeams();
 }
-
-/**
- * Render teams sidebar with game grouping
- */
-function renderTeamsSidebarWithGroups(teams) {
-    const sidebarList = document.getElementById('teamsSidebarList');
-    sidebarList.innerHTML = '';
-
-    const sidebar = document.querySelector('.teams-sidebar');
-    if (sidebar) {
-        sidebar.setAttribute('data-view', window.currentView || 'all');
-    }
-
-    // Use game grouping
-    if (window.currentView !== 'all' && window.currentView !== 'division' && window.currentView !== 'past_seasons') {
-        const sortedTeams = sortTeamsByDivision(teams);
-        originalRenderTeamsSidebar(sortedTeams);
-        return;
-    }
-
-    const sortedTeams = sortTeamsByDivision(teams);
-
-    const gameGroups = {};
-    sortedTeams.forEach(team => {
-        const gameId = team.gameID;
-        const gameTitle = team.GameTitle || 'Unknown Game';
-
-        if (!gameGroups[gameId]) {
-            gameGroups[gameId] = {
-                gameId: gameId,
-                gameTitle: gameTitle,
-                division: team.division || 'Other',
-                hasGameImage: team.has_game_image,
-                teams: []
-            };
-        }
-        gameGroups[gameId].teams.push(team);
-    });
-
-    const sortedGroups = Object.values(gameGroups).sort((a, b) => {
-        const priorityA = getDivisionSortPriority(a.division);
-        const priorityB = getDivisionSortPriority(b.division);
-
-        if (priorityA !== priorityB) {
-            return priorityA - priorityB;
-        }
-
-        return a.gameTitle.localeCompare(b.gameTitle);
-    });
-
-    const collapsedGames = getCollapsedGames();
-
-    sortedGroups.forEach(group => {
-        const isCollapsed = !collapsedGames.has(group.gameId.toString());
-
-        if (isCollapsed) {
-            renderCollapsedGameFolder(group, sidebarList);
-        } else {
-            renderExpandedGameGroup(group, sidebarList);
-        }
-    });
-}
-
-/**
- * Render a collapsed game folder
- */
-function renderCollapsedGameFolder(group, container) {
-    const folderDiv = document.createElement('div');
-    folderDiv.className = 'game-folder-collapsed';
-    folderDiv.setAttribute('data-game-id', group.gameId);
-
-    const hasSelectedTeam = group.teams.some(t => t.TeamID === window.currentSelectedTeamId);
-    if (hasSelectedTeam) {
-        folderDiv.classList.add('active');
-    }
-
-    const teamCount = group.teams.length;
-    const teamWord = teamCount === 1 ? 'team' : 'teams';
-
-    let gameIconHTML;
-    if (group.gameId && group.hasGameImage) {
-        gameIconHTML = `
-            <img src="/game-image/${group.gameId}"
-                 alt="${group.gameTitle}"
-                 loading="lazy"
-                 style="width: 100%; height: 100%; object-fit: cover; border-radius: 8px;"
-                 onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
-            <div style="display: none; width: 100%; height: 100%; align-items: center; justify-content: center;">
-                <i class="fas fa-gamepad"></i>
-            </div>
-        `;
-    } else {
-        gameIconHTML = '<i class="fas fa-gamepad"></i>';
-    }
-
-    folderDiv.innerHTML = `
-        <div class="game-folder-info" onclick="event.stopPropagation(); toggleGameCollapse('${group.gameId}')">
-            <div class="game-folder-icon">
-                ${gameIconHTML}
-            </div>
-            <div class="game-folder-details">
-                <div class="game-folder-name">${group.gameTitle}</div>
-                <div class="game-folder-count">${teamCount} ${teamWord}</div>
-            </div>
-        </div>
-        <button class="game-folder-expand-btn"
-                onclick="event.stopPropagation(); toggleGameCollapse('${group.gameId}')"
-                title="Expand ${group.gameTitle} teams">
-            <i class="fas fa-chevron-down"></i>
-        </button>
-    `;
-
-    container.appendChild(folderDiv);
-}
-
-/**
- * Render an expanded game group with all teams
- */
-function renderExpandedGameGroup(group, container) {
-    const groupDiv = document.createElement('div');
-    groupDiv.className = 'game-group';
-    groupDiv.setAttribute('data-game-id', group.gameId);
-
-    group.teams.forEach((team, index) => {
-        const teamItem = document.createElement('div');
-        teamItem.className = 'team-sidebar-item';
-        teamItem.setAttribute('data-team-id', team.TeamID);
-        teamItem.setAttribute('data-gm-id', team.gm_id || '');
-
-        if (team.TeamID === window.currentSelectedTeamId) {
-            teamItem.classList.add('active');
-        }
-
-        const isGameManager = team.gm_id && team.gm_id === window.currentUserId;
-
-        const collapseBtn = index === 0 ? `
-            <button class="team-collapse-btn"
-                    onclick="event.stopPropagation(); toggleGameCollapse('${group.gameId}')"
-                    title="Collapse ${group.gameTitle} teams">
-                <i class="fas fa-chevron-up"></i>
-            </button>
-        ` : '';
-
-        // Season indicator - ONLY show for PAST teams (season_is_active = 0)
-        const seasonIndicator = (team.season_name && team.season_is_active === 0) ? `
-            <div class="team-sidebar-season" title="Past Season">
-                <span style="color: #94a3b8;">●</span>
-                ${team.season_name}
-            </div>
-        ` : '';
-
-        teamItem.innerHTML = `
-            ${collapseBtn}
-            <div class="team-sidebar-content" onclick="selectTeam('${team.TeamID}')">
-                <div class="team-sidebar-name">${team.teamName}</div>
-                ${seasonIndicator}
-                <div class="team-sidebar-game">${team.GameTitle || 'Unknown Game'}</div>
-                <div class="team-sidebar-meta">
-                    <span><i class="fas fa-users"></i> ${team.member_count || 0}</span>
-                    <span><i class="fas fa-trophy"></i> ${team.teamMaxSize}</span>
-                </div>
-            </div>
-            ${isGameManager && team.season_is_active !== 0 ? `
-                <button class="team-edit-btn"
-                        onclick="event.stopPropagation(); openEditTeamModal('${team.TeamID}', '${team.teamName.replace(/'/g, "\\'")}', ${team.teamMaxSize}, '${team.TeamSizes || ''}')"
-                        title="Edit team">
-                    <i class="fas fa-edit"></i>
-                </button>
-            ` : ''}
-        `;
-
-        groupDiv.appendChild(teamItem);
-    });
-
-    container.appendChild(groupDiv);
-}
-
-/**
- * Override renderTeamsSidebar to use grouping when appropriate
- */
-const originalRenderTeamsSidebar = renderTeamsSidebar;
-renderTeamsSidebar = function(teams) {
-    if (window.currentView === 'all' || window.currentView === 'division' || window.currentView === 'past_seasons') {
-        renderTeamsSidebarWithGroups(teams);
-    } else {
-        originalRenderTeamsSidebar(teams);
-    }
-};
 
 // ============================================
 // DIVISION FILTER
 // ============================================
 
-/**
- * Get currently selected division filter
- */
 function getSelectedDivisionFilter() {
     return sessionStorage.getItem(DIVISION_FILTER_KEY);
 }
 
-/**
- * Set division filter
- */
 function setSelectedDivisionFilter(division) {
     if (division) {
         sessionStorage.setItem(DIVISION_FILTER_KEY, division);
@@ -980,11 +871,8 @@ function setSelectedDivisionFilter(division) {
     }
 }
 
-/**
- * Initialize division filter dropdown
- */
 function initializeDivisionFilter() {
-    const isAdmin = window.userPermissions?.is_admin || window.userPermissions.is_developer || false;
+    const isAdmin = window.userPermissions?.is_admin || window.userPermissions?.is_developer || false;
     if (!isAdmin) return;
 
     const sidebarHeaderTop = document.querySelector('.sidebar-header-top');
@@ -998,9 +886,7 @@ function initializeDivisionFilter() {
         divisionFilterContainer.className = 'division-filter-container hidden';
 
         divisionFilterContainer.innerHTML = `
-            <label for="divisionFilterSelect" class="division-filter-label">
-                Division:
-            </label>
+            <label for="divisionFilterSelect" class="division-filter-label">Division:</label>
             <select id="divisionFilterSelect" class="division-filter-select">
                 <option value="">All Divisions</option>
                 <option value="Strategy">Strategy</option>
@@ -1022,43 +908,26 @@ function initializeDivisionFilter() {
 
     if (window.currentView === 'division') {
         showDivisionFilterDropdown();
-
         const savedDivision = getSelectedDivisionFilter();
         if (savedDivision) {
             const divisionSelect = document.getElementById('divisionFilterSelect');
-            if (divisionSelect) {
-                divisionSelect.value = savedDivision;
-            }
+            if (divisionSelect) divisionSelect.value = savedDivision;
         }
     }
 }
 
-/**
- * Show division filter dropdown
- */
 function showDivisionFilterDropdown() {
     const container = document.getElementById('divisionFilterContainer');
-    if (container) {
-        container.classList.remove('hidden');
-    }
+    if (container) container.classList.remove('hidden');
 }
 
-/**
- * Hide division filter dropdown
- */
 function hideDivisionFilterDropdown() {
     const container = document.getElementById('divisionFilterContainer');
-    if (container) {
-        container.classList.add('hidden');
-    }
+    if (container) container.classList.add('hidden');
 }
 
-/**
- * Handle division filter change
- */
 function handleDivisionFilterChange(event) {
     const selectedDivision = event.target.value;
-
     setSelectedDivisionFilter(selectedDivision || null);
 
     window.currentSelectedTeamId = null;
@@ -1069,22 +938,14 @@ function handleDivisionFilterChange(event) {
 }
 
 // ============================================
-// CREATE TEAM FROM TEAMS TAB
+// CREATE TEAM FLOW
 // ============================================
 
-/**
- * Open create team flow from the Teams sidebar.
- * If the GM manages exactly one game, goes straight to team creation.
- * If they manage multiple, shows a game-picker first.
- * Admins/developers see all games.
- */
 async function openCreateTeam() {
     try {
-        // Check for active season first
         const seasonResponse = await fetch('/api/seasons/current');
         const seasonData = await seasonResponse.json();
 
-        // Fetch games this user manages
         const gamesResponse = await fetch('/api/teams/managed-games');
         const gamesData = await gamesResponse.json();
 
@@ -1094,11 +955,9 @@ async function openCreateTeam() {
         }
 
         if (gamesData.games.length === 1) {
-            // Only one game — go straight to team creation
             const game = gamesData.games[0];
             openCreateTeamModal(game.GameID, game.GameTitle, game.TeamSizes);
         } else {
-            // Multiple games — show picker modal
             openGamePickerModal(gamesData.games);
         }
     } catch (error) {
@@ -1107,11 +966,7 @@ async function openCreateTeam() {
     }
 }
 
-/**
- * Open game picker modal so a GM can choose which game to create a team for.
- */
 function openGamePickerModal(games) {
-    // Remove any existing picker
     const existingModal = document.getElementById('gamePickerModal');
     if (existingModal) existingModal.remove();
 
@@ -1150,9 +1005,7 @@ function openGamePickerModal(games) {
             </div>
             <div class="modal-body">
                 <p class="modal-subtitle">Choose which game to create a team for</p>
-                <div class="game-picker-list">
-                    ${gameListHTML}
-                </div>
+                <div class="game-picker-list">${gameListHTML}</div>
             </div>
         </div>
     `;
@@ -1161,9 +1014,6 @@ function openGamePickerModal(games) {
     document.body.style.overflow = 'hidden';
 }
 
-/**
- * Close the game picker modal
- */
 function closeGamePickerModal() {
     const modal = document.getElementById('gamePickerModal');
     if (modal) {
@@ -1172,34 +1022,51 @@ function closeGamePickerModal() {
     }
 }
 
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Wait one tick to ensure teams.js has already defined selectTeam
+    setTimeout(() => {
+        const _originalSelectTeam = window.selectTeam;
+        if (typeof _originalSelectTeam === 'function') {
+            window.selectTeam = function (teamId) {
+                window.currentSelectedTeamId = teamId;
+                updateSidebarActiveState(teamId);
+                return _originalSelectTeam.apply(this, arguments);
+            };
+        }
+    }, 0);
+});
+
 // ============================================
-// EXPORT FUNCTIONS TO GLOBAL SCOPE
+// EXPORT TO GLOBAL SCOPE
 // ============================================
 
-window.loadTeams = loadTeams;
-window.toggleGameCollapse = toggleGameCollapse;
-window.sortTeamsByDivision = sortTeamsByDivision;
-window.getDivisionSortPriority = getDivisionSortPriority;
-window.renderTeamsSidebarWithGroups = renderTeamsSidebarWithGroups;
-window.initializeViewSwitcher = initializeViewSwitcher;
-window.renderViewSwitcher = renderViewSwitcher;
-window.handleViewChange = handleViewChange;
-window.getSubtitleForView = getSubtitleForView;
-window.initializeDivisionFilter = initializeDivisionFilter;
-window.showDivisionFilterDropdown = showDivisionFilterDropdown;
-window.hideDivisionFilterDropdown = hideDivisionFilterDropdown;
-window.handleDivisionFilterChange = handleDivisionFilterChange;
-window.invalidateTeamsCache = invalidateTeamsCache;
-window.isCacheFresh = isCacheFresh;
-window.openCreateTeam = openCreateTeam;
-window.closeGamePickerModal = closeGamePickerModal;
-window.updateDropdownCount = updateDropdownCount;
+window.loadTeams                        = loadTeams;
+window.toggleGameCollapse               = toggleGameCollapse;
+window.sortTeamsByDivision              = sortTeamsByDivision;
+window.getDivisionSortPriority          = getDivisionSortPriority;
+window.renderTeamsSidebarWithGroups     = renderTeamsSidebarWithGroups;
+window.renderTeamsSidebar               = renderTeamsSidebar;
+window.updateSidebarActiveState         = updateSidebarActiveState;
+window.initializeViewSwitcher           = initializeViewSwitcher;
+window.renderViewSwitcher               = renderViewSwitcher;
+window.handleViewChange                 = handleViewChange;
+window.getSubtitleForView               = getSubtitleForView;
+window.initializeDivisionFilter         = initializeDivisionFilter;
+window.showDivisionFilterDropdown       = showDivisionFilterDropdown;
+window.hideDivisionFilterDropdown       = hideDivisionFilterDropdown;
+window.handleDivisionFilterChange       = handleDivisionFilterChange;
+window.invalidateTeamsCache             = invalidateTeamsCache;
+window.isCacheFresh                     = isCacheFresh;
+window.openCreateTeam                   = openCreateTeam;
+window.closeGamePickerModal             = closeGamePickerModal;
+window.updateDropdownCount              = updateDropdownCount;
 
-//Past Season Exports
-window.initializePastSeasonFilter = initializePastSeasonFilter;
-window.showPastSeasonFilterDropdown = showPastSeasonFilterDropdown;
-window.hidePastSeasonFilterDropdown = hidePastSeasonFilterDropdown;
-window.loadPastSeasonsForTeamsFilter = loadPastSeasonsForTeamsFilter;
-window.handlePastSeasonFilterChange = handlePastSeasonFilterChange;
-window.getSelectedPastSeasonFilter = getSelectedPastSeasonFilter;
-window.setSelectedPastSeasonFilter = setSelectedPastSeasonFilter;
+// Past Season exports
+window.initializePastSeasonFilter       = initializePastSeasonFilter;
+window.showPastSeasonFilterDropdown     = showPastSeasonFilterDropdown;
+window.hidePastSeasonFilterDropdown     = hidePastSeasonFilterDropdown;
+window.loadPastSeasonsForTeamsFilter    = loadPastSeasonsForTeamsFilter;
+window.handlePastSeasonFilterChange     = handlePastSeasonFilterChange;
+window.getSelectedPastSeasonFilter      = getSelectedPastSeasonFilter;
+window.setSelectedPastSeasonFilter      = setSelectedPastSeasonFilter;

--- a/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams-sidebar.js
@@ -122,10 +122,16 @@ async function initializeViewSwitcher() {
             initializeDivisionFilter();
             initializePastSeasonFilter();
         } else {
+            // Mark as initialised (even if empty) so loadTeams does not loop
+            window.availableViews = ['__none__'];
+            window.currentView = window.currentView || 'all';
             hideViewSwitcher();
         }
     } catch (error) {
         console.error('Error initializing view switcher:', error);
+        // Mark as initialised so loadTeams does not loop on repeated calls
+        window.availableViews = ['__none__'];
+        window.currentView = window.currentView || 'all';
         hideViewSwitcher();
     }
 }
@@ -225,8 +231,20 @@ async function loadTeams() {
     const sidebarList = document.getElementById('teamsSidebarList');
     const sidebarEmpty = document.getElementById('teamsSidebarEmpty');
 
+    // Initialise view switcher if not yet done (sentinel '__none__' means already tried)
     if (window.availableViews.length === 0) {
         await initializeViewSwitcher();
+    }
+
+    // Bail out if currentView is still null (init failed and no fallback possible)
+    if (!window.currentView) {
+        console.error('loadTeams: currentView is null after initializeViewSwitcher, aborting');
+        if (sidebarLoading) sidebarLoading.style.display = 'none';
+        if (sidebarEmpty) {
+            sidebarEmpty.innerHTML = '<i class="fas fa-exclamation-triangle"></i><p>Could not load teams. Please refresh.</p>';
+            sidebarEmpty.style.display = 'block';
+        }
+        return;
     }
 
     const selectedDivision = window.currentView === 'division' ? getSelectedDivisionFilter() : null;
@@ -601,7 +619,7 @@ function createTeamTreeItem(team) {
         const editBtn = document.createElement('button');
         editBtn.className = 'team-tree-edit-btn';
         editBtn.title = 'Edit team';
-        editBtn.innerHTML = '<i class="fas fa-pencil-alt"></i>';
+        editBtn.innerHTML = '<i class="fas fa-edit"></i>';
         editBtn.addEventListener('click', e => {
             e.stopPropagation();
             openEditTeamModal(
@@ -1022,6 +1040,10 @@ function closeGamePickerModal() {
     }
 }
 
+// ============================================
+// Wraps the global selectTeam (defined in teams.js) so the sidebar
+// active highlight always reflects the currently selected team.
+// ============================================
 
 document.addEventListener('DOMContentLoaded', () => {
     // Wait one tick to ensure teams.js has already defined selectTeam

--- a/EsportsManagementTool/EsportsManagementTool/static/teams.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams.css
@@ -101,7 +101,7 @@
     border-bottom: 2px solid var(--border-color);
     margin-bottom: 1.5rem;
     max-width: 100%;
-    overflow-x: hidden;
+    overflow: visible;
 }
 
 .team-header-left {
@@ -122,16 +122,149 @@
     font-size: 2.5rem;
 }
 
-.team-header-info h1 {
-    margin: 0 0 0.5rem 0;
-    font-size: 1.75rem;
-    color: var(--text-primary);
+.team-header-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
-.team-header-info p {
+/* Team title row: info icon + h1 side by side */
+.team-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+}
+
+.team-header-info h1 {
     margin: 0;
-    font-size: 0.9375rem;
+    font-size: 1.75rem;
+    color: var(--text-primary);
+    line-height: 1.2;
+}
+
+/* --------------------------------------------
+   TEAM INFO ICON & TOOLTIP
+   -------------------------------------------- */
+.team-info-icon-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.team-info-icon {
+    font-size: 1.25rem;
     color: var(--text-secondary);
+    cursor: default;
+    transition: color 0.2s ease;
+    line-height: 1;
+    display: block;
+}
+
+.team-info-icon-wrapper:hover .team-info-icon {
+    color: var(--stockton-blue);
+}
+
+/* Tooltip panel — appears to the right */
+.team-info-tooltip {
+    position: absolute;
+    left: calc(100% + 12px);
+    top: 50%;
+    transform: translateY(-50%) translateX(-4px);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.75rem 1rem;
+    min-width: 240px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 200;
+    white-space: nowrap;
+}
+
+.team-info-icon-wrapper:hover .team-info-tooltip {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(-50%) translateX(0);
+}
+
+/* Arrow pointing left from tooltip back to icon */
+.team-info-tooltip::before {
+    content: '';
+    position: absolute;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 6px solid transparent;
+    border-right-color: var(--border-color);
+}
+
+.team-info-tooltip::after {
+    content: '';
+    position: absolute;
+    right: calc(100% - 1px);
+    top: 50%;
+    transform: translateY(-50%);
+    border: 6px solid transparent;
+    border-right-color: var(--card-bg);
+}
+
+/* Individual info rows inside tooltip */
+.team-info-tooltip-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.3rem 0;
+}
+
+.team-info-tooltip-row + .team-info-tooltip-row {
+    border-top: 1px solid rgba(255,255,255,0.06);
+    margin-top: 0.2rem;
+    padding-top: 0.5rem;
+}
+
+.team-info-tooltip-label {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+    flex-shrink: 0;
+    min-width: 60px;
+    padding-top: 0.1rem;
+}
+
+.team-info-tooltip-value {
+    font-size: 0.8125rem;
+    color: var(--text-primary);
+    text-align: left;
+    line-height: 1.4;
+    flex: 1;
+    min-width: 0;
+    white-space: normal;
+}
+
+/* Season active dot inside tooltip */
+.tooltip-season-dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    margin-right: 5px;
+    vertical-align: middle;
+    position: relative;
+    top: -1px;
+}
+
+.tooltip-season-dot.active {
+    background: #22c55e;
+}
+
+.tooltip-season-dot.inactive {
+    background: #94a3b8;
 }
 
 /* Header action buttons */
@@ -225,111 +358,11 @@
     font-weight: 600;
 }
 
-/* Team Detail Collapse Button */
-.team-detail-collapse-btn {
-    background: none;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    padding: 0;
-    margin-top: 0.125rem;
-    font-size: 0.875rem;
-    transition: color 0.2s ease, transform 0.2s ease;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-}
-
-.team-detail-collapse-btn:hover {
-    color: var(--stockton-blue);
-    transform: scale(1.1);
-}
-
-.team-detail-collapse-btn i {
-    transition: transform 0.2s ease;
-}
-
-/* Collapsible subheaders container */
-.team-detail-subheaders {
-    max-height: 200px;
-    overflow: hidden;
-    transition: max-height 0.3s ease, opacity 0.3s ease;
-    opacity: 1;
-    flex: 1;
-}
-
-.team-detail-subheaders.collapsed {
-    max-height: 0;
-    opacity: 0;
-}
-
-/* Keep Game text on same line as collapse button */
-#teamDetailGame {
-    display: flex;
-    align-items: center;
-    margin: 0;
-}
-
 /* --------------------------------------------
-   TEAM DETAIL LEAGUES (in subheader)
-   Inline league badges with logos and links
+   TEAM DETAIL LEAGUES (hidden — data lives in tooltip)
    -------------------------------------------- */
-
 #teamDetailLeagues {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    flex-wrap: wrap;
-}
-
-.team-league-link,
-.team-league-item {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.125rem 0.375rem;
-    background: rgba(121, 189, 233, 0.1);
-    border: 1px solid rgba(121, 189, 233, 0.3);
-    border-radius: 4px;
-    color: var(--stockton-blue);
-    text-decoration: none;
-    font-size: 0.6875rem;
-    font-style: normal;
-    transition: all 0.2s;
-}
-
-.team-league-link:hover {
-    background: rgba(121, 189, 233, 0.2);
-    border-color: var(--stockton-blue);
-    transform: translateY(-1px);
-}
-
-.team-league-logo {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    object-fit: cover;
-}
-
-.team-league-icon {
-    font-size: 0.5625rem;
-    color: var(--stockton-blue);
-}
-
-.team-league-name {
-    font-weight: 500;
-}
-
-.team-league-external {
-    font-size: 0.4375rem;
-    opacity: 0.7;
-}
-
-.team-league-link:hover .team-league-external {
-    opacity: 1;
+    display: none !important;
 }
 
 /* --------------------------------------------
@@ -617,7 +650,7 @@
     width: 20px;
     height: 20px;
     border: 2px solid rgba(255, 255, 255, 0.3);
-    border-radius: 50%; /* Circle for radio */
+    border-radius: 50%;
     background: rgba(0, 0, 0, 0.3);
     transition: all 0.2s ease;
     flex-shrink: 0;
@@ -919,9 +952,7 @@
 
 /* Season display in team header */
 #teamDetailSeason {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    display: none !important;
 }
 
 #teamDetailSeason span {
@@ -1043,14 +1074,22 @@
         font-size: 0.75rem;
     }
 
-    #teamDetailLeagues {
-        flex-direction: column;
-        align-items: flex-start;
+    /* On mobile, show tooltip below instead of to the right */
+    .team-info-tooltip {
+        left: 0;
+        top: calc(100% + 10px);
+        transform: translateX(0) translateY(4px);
+        white-space: normal;
+        min-width: 200px;
     }
 
-    .team-league-link,
-    .team-league-item {
-        width: 100%;
+    .team-info-icon-wrapper:hover .team-info-tooltip {
+        transform: translateX(0) translateY(0);
+    }
+
+    .team-info-tooltip::before,
+    .team-info-tooltip::after {
+        display: none;
     }
 }
 
@@ -1058,4 +1097,179 @@
     .teams-main-content {
         padding: 1rem;
     }
+}
+/* --------------------------------------------
+   TEAM STATS SUMMARY BAR
+   Compact three-column strip: Members | Max Size | Next Event
+   -------------------------------------------- */
+.team-stats-summary {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+    align-items: stretch;
+}
+
+.stat-box {
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.65rem 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
+    min-width: 90px;
+    flex-shrink: 0;
+}
+
+.stat-box i {
+    font-size: 1.1rem;
+    color: var(--stockton-blue);
+}
+
+.stat-box .stat-value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.1;
+}
+
+.stat-box .stat-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+}
+
+/* Next event card — fills remaining space */
+#nextScheduledEventContainer {
+    flex: 1;
+    min-width: 0;
+}
+
+.next-scheduled-event-card {
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.65rem 1rem;
+    cursor: pointer;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.2rem;
+}
+
+.next-scheduled-event-card:hover {
+    border-color: var(--stockton-blue);
+    box-shadow: 0 2px 8px rgba(121, 189, 233, 0.15);
+}
+
+.next-event-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.65rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+}
+
+.next-event-header i {
+    color: var(--stockton-blue);
+    font-size: 0.75rem;
+}
+
+.next-event-header h4 {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+}
+
+/* Time + date on one line */
+.next-event-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    flex-wrap: wrap;
+}
+
+.next-event-meta i {
+    margin-right: 0.2rem;
+    font-size: 0.75rem;
+}
+
+.next-event-time,
+.next-event-date {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+}
+
+.next-event-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.next-event-type {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    background: rgba(121, 189, 233, 0.15);
+    color: var(--stockton-blue);
+    align-self: flex-start;
+}
+
+.next-event-type.match {
+    background: rgba(239, 68, 68, 0.15);
+    color: #ef4444;
+}
+
+.next-event-type.practice {
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+}
+
+.next-event-type.tournament {
+    background: rgba(234, 179, 8, 0.15);
+    color: #eab308;
+}
+
+.next-scheduled-event-empty {
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    height: 100%;
+}
+
+.next-scheduled-event-empty i {
+    color: var(--stockton-blue);
+    opacity: 0.5;
+}
+
+.next-scheduled-event-empty p {
+    margin: 0;
 }

--- a/EsportsManagementTool/EsportsManagementTool/static/teams.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams.js
@@ -85,55 +85,35 @@ async function loadTeamDetails(teamId) {
             }
 
             document.getElementById('teamDetailTitle').textContent = team.title;
-            document.getElementById('teamDetailGame').textContent = `Game: ${team.game_title || 'Unknown'}`;
+
+            // Keep hidden elements populated so existing JS that reads them still works
+            const gameEl = document.getElementById('teamDetailGame');
+            if (gameEl) gameEl.textContent = `Game: ${team.game_title || 'Unknown'}`;
 
             const divisionElement = document.getElementById('teamDetailDivision');
             if (divisionElement) {
                 if (team.division) {
                     divisionElement.textContent = `Division: ${team.division}`;
-                    divisionElement.style.display = 'block';
                 } else {
-                    divisionElement.style.display = 'none';
+                    divisionElement.textContent = '';
                 }
             }
 
-            // Display team leagues
-            await displayTeamLeaguesInSubheader(teamId);
-
-            // Display season information
+            // Display season information (hidden element kept for compat)
             const seasonElement = document.getElementById('teamDetailSeason');
             if (seasonElement) {
                 if (team.season_name) {
-                    const seasonStatus = team.season_is_active ?
-                        '<span style="color: #22c55e;">●</span>' :
-                        '<span style="color: #94a3b8;">●</span>';
-                    seasonElement.innerHTML = `${seasonStatus} Season: ${team.season_name}`;
-                    seasonElement.style.display = 'block';
+                    seasonElement.textContent = `Season: ${team.season_name}`;
                 } else {
                     seasonElement.textContent = 'Season: Not assigned';
-                    seasonElement.style.display = 'block';
                 }
             }
 
-            //Applies a collapsed team details state
-            const isCollapsed = getCollapsedTeamDetailsState();
-            const subheadersContainer = document.getElementById('teamDetailSubheaders');
-            const collapseBtn = document.getElementById('teamDetailCollapseBtn');
-            const icon = collapseBtn?.querySelector('i');
+            // Populate the info tooltip
+            populateTeamInfoTooltip(team);
 
-            if (subheadersContainer && isCollapsed) {
-                subheadersContainer.classList.add('collapsed');
-                if (icon) {
-                    icon.classList.remove('fa-chevron-up');
-                    icon.classList.add('fa-chevron-down');
-                }
-            } else if (subheadersContainer) {
-                subheadersContainer.classList.remove('collapsed');
-                if (icon) {
-                    icon.classList.remove('fa-chevron-down');
-                    icon.classList.add('fa-chevron-up');
-                }
-            }
+            // Display team leagues (also updates tooltip leagues row)
+            await displayTeamLeaguesInSubheader(teamId);
 
             const teamIconLarge = document.querySelector('.team-icon-large');
             if (teamIconLarge) {
@@ -210,7 +190,51 @@ async function loadTeamDetails(teamId) {
     }
 }
 
-// Display leagues in team details
+// ============================================
+// TEAM INFO TOOLTIP
+// ============================================
+
+function populateTeamInfoTooltip(team) {
+    // Game row — always shown
+    const tooltipGameValue = document.getElementById('tooltipGameValue');
+    if (tooltipGameValue) {
+        tooltipGameValue.textContent = team.game_title || '—';
+    }
+
+    // Division row — only shown when present
+    const tooltipDivision = document.getElementById('tooltipDivision');
+    const tooltipDivisionValue = document.getElementById('tooltipDivisionValue');
+    if (tooltipDivision && tooltipDivisionValue) {
+        if (team.division) {
+            tooltipDivisionValue.textContent = team.division;
+            tooltipDivision.style.display = 'flex';
+        } else {
+            tooltipDivision.style.display = 'none';
+        }
+    }
+
+    // Season row — only shown when present
+    const tooltipSeason = document.getElementById('tooltipSeason');
+    const tooltipSeasonValue = document.getElementById('tooltipSeasonValue');
+    if (tooltipSeason && tooltipSeasonValue) {
+        if (team.season_name) {
+            const isActive = team.season_is_active === 1;
+            tooltipSeasonValue.innerHTML =
+                `<span class="tooltip-season-dot ${isActive ? 'active' : 'inactive'}"></span>${team.season_name}`;
+            tooltipSeason.style.display = 'flex';
+        } else {
+            tooltipSeason.style.display = 'none';
+        }
+    }
+
+    // Reset leagues row until the async fetch completes
+    const tooltipLeagues = document.getElementById('tooltipLeagues');
+    if (tooltipLeagues) {
+        tooltipLeagues.style.display = 'none';
+    }
+}
+
+// Display leagues — updates both the hidden compat element and the tooltip
 async function displayTeamLeaguesInSubheader(teamId) {
     try {
         const response = await fetch(`/api/teams/${teamId}/leagues`);
@@ -223,8 +247,12 @@ async function displayTeamLeaguesInSubheader(teamId) {
             return;
         }
 
+        // Tooltip league row elements
+        const tooltipLeagues = document.getElementById('tooltipLeagues');
+        const tooltipLeaguesValue = document.getElementById('tooltipLeaguesValue');
+
         if (data.success && data.leagues && data.leagues.length > 0) {
-            // Build leagues HTML with logos and links
+            // Build leagues HTML for the hidden compat element
             const leaguesHTML = data.leagues.map(league => {
                 const logoHTML = league.logo
                     ? `<img src="${league.logo}" alt="${league.name}" class="team-league-logo">`
@@ -232,7 +260,6 @@ async function displayTeamLeaguesInSubheader(teamId) {
 
                 const content = `${logoHTML}<span class="team-league-name">${league.name}</span>`;
 
-                // If there's a website URL, make it a link
                 if (league.website_url) {
                     return `
                         <a href="${league.website_url}"
@@ -250,55 +277,22 @@ async function displayTeamLeaguesInSubheader(teamId) {
             }).join('');
 
             leaguesElement.innerHTML = `League(s): ${leaguesHTML}`;
-            leaguesElement.style.display = 'block';
+
+            // Populate tooltip with plain league names (comma-separated)
+            if (tooltipLeagues && tooltipLeaguesValue) {
+                tooltipLeaguesValue.textContent = data.leagues.map(l => l.name).join(', ');
+                tooltipLeagues.style.display = 'flex';
+            }
         } else {
             leaguesElement.style.display = 'none';
+            if (tooltipLeagues) tooltipLeagues.style.display = 'none';
         }
     } catch (error) {
         console.error('Error loading team leagues:', error);
         const leaguesElement = document.getElementById('teamDetailLeagues');
-        if (leaguesElement) {
-            leaguesElement.style.display = 'none';
-        }
-    }
-}
-
-// Storage key for collapsed team details
-const COLLAPSED_TEAM_DETAILS_KEY = 'teams_collapsed_details';
-
-// Get collapsed team details state
-function getCollapsedTeamDetailsState() {
-    const stored = sessionStorage.getItem(COLLAPSED_TEAM_DETAILS_KEY);
-    return stored === 'true';
-}
-
-// Save collapsed team details state
-function saveCollapsedTeamDetailsState(isCollapsed) {
-    sessionStorage.setItem(COLLAPSED_TEAM_DETAILS_KEY, isCollapsed.toString());
-}
-
-// Toggle team detail collapse
-function toggleTeamDetailCollapse() {
-    const detailsContainer = document.getElementById('teamDetailSubheaders');
-    const toggleBtn = document.getElementById('teamDetailCollapseBtn');
-    const icon = toggleBtn?.querySelector('i');
-
-    if (!detailsContainer || !toggleBtn || !icon) return;
-
-    const isCollapsed = detailsContainer.classList.contains('collapsed');
-
-    if (isCollapsed) {
-        // Expand
-        detailsContainer.classList.remove('collapsed');
-        icon.classList.remove('fa-chevron-down');
-        icon.classList.add('fa-chevron-up');
-        saveCollapsedTeamDetailsState(false);
-    } else {
-        // Collapse
-        detailsContainer.classList.add('collapsed');
-        icon.classList.remove('fa-chevron-up');
-        icon.classList.add('fa-chevron-down');
-        saveCollapsedTeamDetailsState(true);
+        if (leaguesElement) leaguesElement.style.display = 'none';
+        const tooltipLeagues = document.getElementById('tooltipLeagues');
+        if (tooltipLeagues) tooltipLeagues.style.display = 'none';
     }
 }
 
@@ -353,16 +347,18 @@ async function loadNextScheduledEvent(teamId, gameId) {
                         <h4>Next Scheduled Event</h4>
                     </div>
                     <div class="next-event-content">
-                        <div class="next-event-time">
-                            ${event.is_all_day ?
-                                '<i class="fas fa-calendar"></i> All Day' :
-                                `<i class="fas fa-clock"></i> ${event.start_time}`
-                            }
+                        <div class="next-event-meta">
+                            <span class="next-event-time">
+                                ${event.is_all_day ?
+                                    '<i class="fas fa-calendar"></i> All Day' :
+                                    `<i class="fas fa-clock"></i> ${event.start_time}`
+                                }
+                            </span>
+                            <span class="next-event-date">
+                                <i class="fas fa-calendar-day"></i> ${event.date}
+                            </span>
                         </div>
                         <div class="next-event-title">${event.name}</div>
-                        <div class="next-event-date">
-                            <i class="fas fa-calendar-day"></i> ${event.date}
-                        </div>
                         <span class="next-event-type ${event.event_type.toLowerCase()}">${event.event_type}</span>
                     </div>
                 </div>
@@ -1174,7 +1170,7 @@ function formatTimeRemaining(days, hours) {
 // ============================================
 window.selectTeam = selectTeam;
 window.confirmDeleteSelectedTeam = confirmDeleteSelectedTeam;
-window.toggleTeamDetailCollapse = toggleTeamDetailCollapse;
+window.populateTeamInfoTooltip = populateTeamInfoTooltip;
 
 //Modals
 window.openAddTeamMembersModal = openAddTeamMembersModal;

--- a/EsportsManagementTool/EsportsManagementTool/teams.py
+++ b/EsportsManagementTool/EsportsManagementTool/teams.py
@@ -702,10 +702,14 @@ def get_team_sidebar_filters():
 
         views.sort(key=lambda x: x['priority'])
 
+        # Always guarantee at least one view so the sidebar never infinite-loads
+        if not views:
+            views.append({'value': 'all', 'label': 'All Teams', 'priority': 1})
+
         return jsonify({
             'success': True,
             'views': views,
-            'has_multiple': len(views) > 0
+            'has_multiple': len(views) > 1
         })
 
     except Exception as e:

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -914,7 +914,7 @@
                         <button id="createTeamSidebarBtn"
                                 class="btn btn-primary btn-create-team-sidebar"
                                 onclick="openCreateTeam()">
-                            <i class="fas fa-plus"></i> Create Team
+                            <i class="fas fa-plus"></i>
                         </button>
                         {% endif %}
                     </div>
@@ -965,25 +965,41 @@
                                 <i class="fas fa-shield-alt"></i>
                             </div>
                             <div class="team-header-info">
-                                <h1 id="teamDetailTitle">Team Name</h1>
-
-                                <!-- Button outside the collapsible container -->
-                                <div style="display: flex; align-items: flex-start; gap: 0.5rem;">
-                                    <button id="teamDetailCollapseBtn"
-                                            class="team-detail-collapse-btn"
-                                            onclick="toggleTeamDetailCollapse()"
-                                            title="Toggle details">
-                                        <i class="fas fa-chevron-up"></i>
-                                    </button>
-
-                                    <!-- Wrap subheaders in collapsible container -->
-                                    <div id="teamDetailSubheaders" class="team-detail-subheaders">
-                                        <p id="teamDetailGame" style="margin: 0;">Game: Mario Kart</p>
-                                        <p id="teamDetailDivision" style="display: none; margin: 0.25rem 0 0 0; font-size: 0.8125rem; color: var(--text-secondary); font-style: italic;"></p>
-                                        <p id="teamDetailLeagues" style="display: none; margin: 0.25rem 0 0 0; font-size: 0.8125rem; color: var(--text-secondary); font-style: italic;"></p>
-                                         <p id="teamDetailSeason" style="display: none; margin: 0.25rem 0 0 0; font-size: 0.8125rem; color: var(--text-secondary); font-style: italic;"></p>
+                                <!-- Title row: team name (left) + info icon (right) -->
+                                <div class="team-title-row">
+                                    <h1 id="teamDetailTitle">Team Name</h1>
+                                    <!-- Info icon with hover tooltip -->
+                                    <div class="team-info-icon-wrapper">
+                                        <i class="fas fa-info-circle team-info-icon" id="teamInfoIcon"></i>
+                                        <div class="team-info-tooltip" id="teamInfoTooltip">
+                                            <!-- Game — always shown -->
+                                            <div class="team-info-tooltip-row" id="tooltipGame">
+                                                <span class="team-info-tooltip-label">Game</span>
+                                                <span class="team-info-tooltip-value" id="tooltipGameValue">—</span>
+                                            </div>
+                                            <!-- Division — shown only when present -->
+                                            <div class="team-info-tooltip-row" id="tooltipDivision" style="display: none;">
+                                                <span class="team-info-tooltip-label">Division</span>
+                                                <span class="team-info-tooltip-value" id="tooltipDivisionValue">—</span>
+                                            </div>
+                                            <!-- League(s) — shown only when present -->
+                                            <div class="team-info-tooltip-row" id="tooltipLeagues" style="display: none;">
+                                                <span class="team-info-tooltip-label">League(s)</span>
+                                                <span class="team-info-tooltip-value" id="tooltipLeaguesValue">—</span>
+                                            </div>
+                                            <!-- Season — shown only when present -->
+                                            <div class="team-info-tooltip-row" id="tooltipSeason" style="display: none;">
+                                                <span class="team-info-tooltip-label">Season</span>
+                                                <span class="team-info-tooltip-value" id="tooltipSeasonValue">—</span>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
+                                <!-- Hidden compat elements — JS still writes to these; they stay hidden -->
+                                <p id="teamDetailGame" style="display: none;"></p>
+                                <p id="teamDetailDivision" style="display: none;"></p>
+                                <p id="teamDetailLeagues" style="display: none;"></p>
+                                <p id="teamDetailSeason" style="display: none;"></p>
                             </div>
                         </div>
 


### PR DESCRIPTION
**Finished KAN - 127 Teams Tab Overhaul**
- Added new dropdown system to the sidebar
      - Sidebar now includes trees branching to teams for visual effect
      - Accounted for filters with the changes to sidebar
      - Create Team button switched to a +
      - Visuals can be seen within the teams redesign thread if helpful

- Adjusted title banner
      - Consolidated team info by adding information i
      - Moved the next scheduled event date and time next to each other.
      - Shrink members and max size boxes

- Removed previous collapse functionality on the sidebar and title to account for new dropdowns and title bar

