### PR TITLE
Feature/kan 123 event tab redesign

### DIFF
--- a/EsportsManagementTool/EsportsManagementTool/communities.py
+++ b/EsportsManagementTool/EsportsManagementTool/communities.py
@@ -1196,7 +1196,7 @@ def get_game_list():
         cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
 
         try:
-            cursor.execute("SELECT GameID, GameTitle FROM games ORDER BY GameTitle ASC")
+            cursor.execute("SELECT GameID, GameTitle, Abbreviation FROM games ORDER BY GameTitle ASC")
             games = cursor.fetchall()
 
             return jsonify({'success': True, 'games': games}), 200

--- a/EsportsManagementTool/EsportsManagementTool/events.py
+++ b/EsportsManagementTool/EsportsManagementTool/events.py
@@ -2,16 +2,16 @@
 Event Management Routes
 Module for all event-related functionality
 """
-from EsportsManagementTool.universal_helpers import get_user_permissions, format_time_to_12hr
+from EsportsManagementTool.universal_helpers import get_user_permissions, format_time_raw, format_time_to_12hr
 from flask import request, jsonify, session, render_template
 from datetime import datetime, timedelta
 import MySQLdb.cursors
 import json
 from EsportsManagementTool import localize_datetime, EST
 
-
+# Primary routes for event CRUD operations
 def register_event_routes(app, mysql, login_required, roles_required):
-    """Register all event-related routes with the Flask app"""
+    """Register all event-related routes"""
 
     @app.route('/event-register', methods=['GET', 'POST'])
     @roles_required('admin', 'gm', 'developer')
@@ -36,13 +36,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
                     game_display = ', '.join(selected_games) if selected_games else None
 
                     # Get primary game_id
-                    primary_game_id = None
-                    if selected_games:
-                        first_game_title = selected_games[0]
-                        cursor.execute('SELECT gameID FROM games WHERE GameTitle = %s', (first_game_title,))
-                        game_result = cursor.fetchone()
-                        if game_result:
-                            primary_game_id = game_result['gameID']
+                    primary_game_id = get_primary_game_id(cursor, selected_games)
 
                     # Determine season
                     season_id = get_season_for_event_date(cursor, eventDate)
@@ -61,15 +55,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
                     # Insert games into event_games table
                     if selected_games:
-                        for game_title in selected_games:
-                            cursor.execute('SELECT gameID FROM games WHERE GameTitle = %s', (game_title,))
-                            game_result = cursor.fetchone()
-                            if game_result:
-                                game_id = game_result['gameID']
-                                cursor.execute(
-                                    'INSERT IGNORE INTO event_games (event_id, game_id) VALUES (%s, %s)',
-                                    (event_id, game_id)
-                                )
+                        sync_event_games(cursor, event_id, selected_games)
 
                     mysql.connection.commit()
                     msg = 'Event Registered!\nYou have 24 hours to delete this event.'
@@ -100,9 +86,9 @@ def register_event_routes(app, mysql, login_required, roles_required):
     @login_required
     def get_events():
         """Get events based on user role and filters"""
+        cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
         try:
             user_id = session['id']
-            cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
 
             # Get user permissions
             permissions = get_user_permissions(user_id)
@@ -132,7 +118,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 active_season = cursor.fetchone()
                 if active_season:
                     season_id = active_season['season_id']
-                    print(f"   📅 No season specified, defaulting to active season: {season_id}")
 
             # Build base conditions
             conditions = []
@@ -186,7 +171,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
             # Determine sort order (upcoming filters should sort ascending, others descending)
             is_upcoming_filter = event_filter in ['upcoming', 'upcoming14']
 
-            # Add visibility filtering - UPDATED TO INCLUDE GM CREATOR ACCESS
+            # Add visibility filtering
             visibility_clause = """
                 (
                     ge.schedule_id IS NULL
@@ -208,92 +193,35 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 )
             """
 
-            # Handle "subscribed" filter - applies to all users
+            # Handle subscribed filter's extra join and condition
+            sort = 'ASC' if is_upcoming_filter else 'DESC'
+            subscription_join = ""
+            subscription_condition = ""
             if event_filter == 'subscribed':
-                query = f"""
-                    SELECT 
-                        ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
-                        ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
-                        ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active,
-                        t.teamName as team_name
-                    FROM generalevents ge
-                    LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
-                    LEFT JOIN seasons s ON ge.season_id = s.season_id
-                    LEFT JOIN teams t ON se.team_id = t.TeamID
-                    INNER JOIN event_subscriptions es ON ge.EventID = es.event_id
-                    WHERE {where_clause} AND es.user_id = %s
-                    AND {visibility_clause}
-                    ORDER BY ge.Date DESC, ge.StartTime DESC
-                """
+                subscription_join = "INNER JOIN event_subscriptions es ON ge.EventID = es.event_id"
+                subscription_condition = "AND es.user_id = %s"
                 params.append(user_id)
-                params.extend([user_id, user_id, user_id, user_id])  # For visibility clause
-                cursor.execute(query, tuple(params))
 
-            # Build query based on user role
-            elif is_admin or is_developer:
-                query = f"""
-                    SELECT 
-                        ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
-                        ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
-                        ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active,
-                        t.teamName as team_name
-                    FROM generalevents ge
-                    LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
-                    LEFT JOIN seasons s ON ge.season_id = s.season_id
-                    LEFT JOIN teams t ON se.team_id = t.TeamID
-                    WHERE {where_clause}
-                    AND {visibility_clause}
-                    ORDER BY ge.Date {'ASC' if is_upcoming_filter else 'DESC'}, 
-                             ge.StartTime {'ASC' if is_upcoming_filter else 'DESC'}
-                """
-                params.extend([user_id, user_id, user_id, user_id])  # For visibility clause
-                cursor.execute(query, tuple(params))
-
-            elif is_gm:
-                query = f"""
-                    SELECT 
-                        ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
-                        ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
-                        ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active,
-                        t.teamName as team_name
-                    FROM generalevents ge
-                    LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
-                    LEFT JOIN seasons s ON ge.season_id = s.season_id
-                    LEFT JOIN teams t ON se.team_id = t.TeamID
-                    WHERE {where_clause}
-                    AND {visibility_clause}
-                    ORDER BY ge.Date {'ASC' if is_upcoming_filter else 'DESC'}, 
-                             ge.StartTime {'ASC' if is_upcoming_filter else 'DESC'}
-                """
-                params.extend([user_id, user_id, user_id, user_id])  # For visibility clause
-                cursor.execute(query, tuple(params))
-
-            else:
-                # Regular users see ALL events (with visibility filtering)
-                query = f"""
-                    SELECT 
-                        ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
-                        ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
-                        ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active,
-                        t.teamName as team_name
-                    FROM generalevents ge
-                    LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
-                    LEFT JOIN seasons s ON ge.season_id = s.season_id
-                    LEFT JOIN teams t ON se.team_id = t.TeamID
-                    WHERE {where_clause}
-                    AND {visibility_clause}
-                    ORDER BY ge.Date {'ASC' if is_upcoming_filter else 'DESC'}, 
-                             ge.StartTime {'ASC' if is_upcoming_filter else 'DESC'}
-                """
-                params.extend([user_id, user_id, user_id, user_id])  # For visibility clause
-                cursor.execute(query, tuple(params))
-
+            query = f"""
+                SELECT 
+                    ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
+                    ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
+                    ge.is_scheduled, ge.schedule_id, ge.created_at,
+                    s.season_name, s.is_active as season_is_active,
+                    t.teamName as team_name
+                FROM generalevents ge
+                LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
+                LEFT JOIN seasons s ON ge.season_id = s.season_id
+                LEFT JOIN teams t ON se.team_id = t.TeamID
+                {subscription_join}
+                WHERE {where_clause}
+                {subscription_condition}
+                AND {visibility_clause}
+                ORDER BY ge.Date {sort}, ge.StartTime {sort}
+            """
+            params.extend([user_id, user_id, user_id, user_id])  # For visibility clause
+            cursor.execute(query, tuple(params))
             events = cursor.fetchall()
-            cursor.close()
 
             # Process events
             events_list = []
@@ -309,6 +237,8 @@ def register_event_routes(app, mysql, login_required, roles_required):
                     'date_raw': event['Date'].strftime('%Y-%m-%d'),
                     'start_time': start_time_str,
                     'end_time': end_time_str,
+                    'start_time_raw': format_time_raw(event['StartTime']),
+                    'end_time_raw': format_time_raw(event['EndTime']),
                     'event_type': event['EventType'] or 'Event',
                     'game': event['Game'] or 'N/A',
                     'location': event['Location'] or 'TBD',
@@ -337,6 +267,8 @@ def register_event_routes(app, mysql, login_required, roles_required):
         except Exception as e:
             print(f"Error fetching events: {str(e)}")
             return jsonify({'success': False, 'message': 'Failed to fetch events'}), 500
+        finally:
+            cursor.close()
 
 
     @app.route('/api/event/<int:event_id>')
@@ -460,15 +392,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 return jsonify({'success': False, 'message': 'Event not found'}), 404
 
             # Check permissions
-            if is_admin:
-                can_edit = True
-            elif is_developer:
-                can_edit = True
-            elif is_gm and event['created_by'] == user_id:
-                can_edit = True
-            else:
-                can_edit = False
-
+            can_edit = is_admin or is_developer or (is_gm and event['created_by'] == user_id)
             if not can_edit:
                 cursor.close()
                 return jsonify({'success': False, 'message': 'You do not have permission to edit this event'}), 403
@@ -481,25 +405,14 @@ def register_event_routes(app, mysql, login_required, roles_required):
             game_display = ', '.join(selected_games) if selected_games else None
 
             # Get primary game_id (first selected game)
-            primary_game_id = None
-            if selected_games:
-                first_game_title = selected_games[0]
-                cursor.execute('SELECT gameID FROM games WHERE GameTitle = %s', (first_game_title,))
-                game_result = cursor.fetchone()
-                if game_result:
-                    primary_game_id = game_result['gameID']
-            league_id = data.get('league_id')
+            primary_game_id = get_primary_game_id(cursor, selected_games)
 
             # ============================================
             # RECALCULATE SEASON BASED ON NEW DATE
             # ============================================
             new_event_date = data['event_date']
+            league_id = data.get('league_id')
             season_id = get_season_for_event_date(cursor, new_event_date)
-
-            if season_id:
-                print(f"   Updated event date {new_event_date} assigned to season_id: {season_id}")
-            else:
-                print(f"   Updated event date {new_event_date} has no season assignment")
 
             # Update the event
             cursor.execute("""
@@ -528,15 +441,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
             # Insert new game associations
             if selected_games:
-                for game_title in selected_games:
-                    cursor.execute('SELECT gameID FROM games WHERE GameTitle = %s', (game_title,))
-                    game_result = cursor.fetchone()
-                    if game_result:
-                        game_id = game_result['gameID']
-                        cursor.execute(
-                            'INSERT IGNORE INTO event_games (event_id, game_id) VALUES (%s, %s)',
-                            (event_id, game_id)
-                        )
+                sync_event_games(cursor, event_id, selected_games)
 
             mysql.connection.commit()
             cursor.close()
@@ -551,7 +456,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
     @app.route('/api/events/<int:event_id>', methods=['DELETE'])
     @login_required
-    def delete_event_from_tab(event_id):
+    def delete_event(event_id):
         """Delete an event with time-based permissions"""
         try:
             user_id = session['id']
@@ -637,100 +542,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
             return jsonify({'success': False, 'message': 'Failed to delete event'}), 500
 
 
-    @app.route('/delete-event', methods=['POST'])
-    @login_required
-    def delete_event_modal():
-        """Delete an event from the modal view with time-based permissions"""
-        try:
-            user_id = session['id']
-            data = request.get_json()
-            event_id = data.get('event_id')
-
-            if not event_id:
-                return jsonify({'success': False, 'message': 'Event ID is required'}), 400
-
-            cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
-
-            permissions = get_user_permissions(user_id)
-            is_developer = permissions['is_developer']
-            is_admin = permissions['is_admin']
-
-            # Check deletion permissions
-            can_delete, reason = can_delete_event(cursor, event_id, user_id, is_developer, is_admin)
-
-            if not can_delete:
-                cursor.close()
-                return jsonify({'success': False, 'message': reason}), 403
-
-            # Get event details (including schedule_id)
-            cursor.execute("""
-                SELECT EventName, schedule_id 
-                FROM generalevents 
-                WHERE EventID = %s
-            """, (event_id,))
-            event = cursor.fetchone()
-
-            if not event:
-                cursor.close()
-                return jsonify({'success': False, 'message': 'Event not found'}), 404
-
-            event_name = event['EventName']
-            schedule_id = event.get('schedule_id')
-
-            # Delete the event
-            cursor.execute("DELETE FROM generalevents WHERE EventID = %s", (event_id,))
-            mysql.connection.commit()
-
-            # If event was from a schedule, check if schedule should be cleaned up
-            if schedule_id:
-                cursor.execute("""
-                    SELECT COUNT(*) as event_count
-                    FROM generalevents
-                    WHERE schedule_id = %s
-                """, (schedule_id,))
-
-                result = cursor.fetchone()
-                event_count = result['event_count'] if result else 0
-
-                # If no events remain, delete the schedule
-                if event_count == 0:
-                    cursor.execute("""
-                        SELECT event_name
-                        FROM scheduled_events
-                        WHERE schedule_id = %s
-                    """, (schedule_id,))
-
-                    schedule = cursor.fetchone()
-                    schedule_name = schedule['event_name'] if schedule else 'Unknown'
-
-                    cursor.execute("""
-                        DELETE FROM scheduled_events
-                        WHERE schedule_id = %s
-                    """, (schedule_id,))
-
-                    mysql.connection.commit()
-                    cursor.close()
-
-                    return jsonify({
-                        'success': True,
-                        'message': f'Event "{event_name}" deleted successfully.',
-                        'schedule_deleted': True,
-                        'schedule_name': schedule_name
-                    }), 200
-
-            cursor.close()
-            return jsonify({
-                'success': True,
-                'message': f'Event "{event_name}" deleted successfully',
-                'schedule_deleted': False
-            }), 200
-
-        except Exception as e:
-            print(f"Error deleting event from modal: {str(e)}")
-            mysql.connection.rollback()
-            return jsonify({'success': False, 'message': 'Failed to delete event'}), 500
-
-
     @app.route('/api/event/<int:event_id>/subscription-status')
     @login_required
     def subscription_status(event_id):
@@ -738,25 +549,28 @@ def register_event_routes(app, mysql, login_required, roles_required):
         user_id = session['id']
         cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
 
-        # Check if user subscribed to this event
-        cursor.execute("""
-            SELECT * FROM event_subscriptions
-            WHERE user_id=%s AND event_id=%s
-        """, (user_id, event_id))
-        subscription = cursor.fetchone()
+        try:
+            # Check if user subscribed to this event
+            cursor.execute("""
+                SELECT * FROM event_subscriptions
+                WHERE user_id=%s AND event_id=%s
+            """, (user_id, event_id))
+            subscription = cursor.fetchone()
 
-        # Check global notification preference
-        cursor.execute("""
-            SELECT enable_notifications FROM notification_preferences
-            WHERE user_id=%s
-        """, (user_id,))
-        pref = cursor.fetchone()
-        cursor.close()
+            # Check global notification preference
+            cursor.execute("""
+                SELECT enable_notifications FROM notification_preferences
+                WHERE user_id=%s
+            """, (user_id,))
+            pref = cursor.fetchone()
 
-        return jsonify({
-            'subscribed': bool(subscription),
-            'notifications_enabled': pref['enable_notifications'] if pref else False
-        })
+            return jsonify({
+                'subscribed': bool(subscription),
+                'notifications_enabled': pref['enable_notifications'] if pref else False
+            })
+        finally:
+            cursor.close()
+
 
     @app.route('/api/event/<int:event_id>/toggle-subscription', methods=['POST'])
     @login_required
@@ -943,6 +757,25 @@ def get_season_for_event_date(cursor, event_date):
         print(f"  Error determining season for event date {event_date}: {str(e)}")
         return None
 
+def get_primary_game_id(cursor, selected_games):
+    """Return the gameID of the first game in the list, or None."""
+    if not selected_games:
+        return None
+    cursor.execute('SELECT gameID FROM games WHERE GameTitle = %s', (selected_games[0],))
+    result = cursor.fetchone()
+    return result['gameID'] if result else None
+
+
+def sync_event_games(cursor, event_id, selected_games):
+    """Insert game associations for an event, looking up IDs by title."""
+    for game_title in selected_games:
+        cursor.execute('SELECT gameID FROM games WHERE GameTitle = %s', (game_title,))
+        result = cursor.fetchone()
+        if result:
+            cursor.execute(
+                'INSERT IGNORE INTO event_games (event_id, game_id) VALUES (%s, %s)',
+                (event_id, result['gameID'])
+            )
 
 def can_delete_event(cursor, event_id, user_id, is_developer, is_admin):
     """

--- a/EsportsManagementTool/EsportsManagementTool/events.py
+++ b/EsportsManagementTool/EsportsManagementTool/events.py
@@ -354,6 +354,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 FROM generalevents ge
                 LEFT JOIN seasons s ON ge.season_id = s.season_id
                 LEFT JOIN league l ON ge.league_id = l.id
+                LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
                 WHERE ge.EventID = %s
             """, (event_id,))
 
@@ -379,7 +380,9 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 'season_name': event.get('season_name'),
                 'season_is_active': event.get('season_is_active', 0),
                 'league_id': event.get('league_id'),
-                'league_name': event.get('league_name')
+                'league_name': event.get('league_name'),
+                'is_scheduled': bool(event.get('is_scheduled', False)),
+                'schedule_id': event.get('schedule_id')
             }
 
             return jsonify(event_data)

--- a/EsportsManagementTool/EsportsManagementTool/events.py
+++ b/EsportsManagementTool/EsportsManagementTool/events.py
@@ -1,186 +1,22 @@
 """
 Event Management Routes
-Consolidated module for all event-related functionality
+Module for all event-related functionality
 """
-from EsportsManagementTool.universal_helpers import get_user_permissions
+from EsportsManagementTool.universal_helpers import get_user_permissions, format_time_to_12hr
 from flask import request, jsonify, session, render_template
 from datetime import datetime, timedelta
 import MySQLdb.cursors
+import json
 from EsportsManagementTool import localize_datetime, EST
 
-"""
-Helper function to determine which season an event will be tied to.
-@param - event_date is the date the event takes place. This is used to calculate which season it will be a part of.
-"""
-def get_season_for_event_date(cursor, event_date):
-    """
-    Determine which season an event belongs to based on its date.
-
-    Logic:
-    1. If event falls within an active or past season's date range, use that season
-    2. If event is before all seasons, return None
-    3. If event is between seasons, assign to the most recent previous season
-    4. If event is after all seasons, assign to the most recent season
-
-    Args:
-        cursor: MySQL cursor
-        event_date: Date object or string in YYYY-MM-DD format
-
-    Returns:
-        int or None: season_id to assign, or None if no seasons exist
-    """
-    from datetime import datetime
-
-    # Convert string to date if needed
-    if isinstance(event_date, str):
-        event_date = datetime.strptime(event_date, '%Y-%m-%d').date()
-
-    try:
-        # Check if event falls within any season's date range
-        cursor.execute("""
-            SELECT season_id, season_name, start_date, end_date
-            FROM seasons
-            WHERE %s BETWEEN start_date AND end_date
-            ORDER BY start_date DESC
-            LIMIT 1
-        """, (event_date,))
-
-        direct_match = cursor.fetchone()
-        if direct_match:
-            print(f"   📅 Event date {event_date} falls within season '{direct_match['season_name']}'")
-            return direct_match['season_id']
-
-        # Event doesn't fall within any season - find the most recent previous season
-        cursor.execute("""
-            SELECT season_id, season_name, start_date, end_date
-            FROM seasons
-            WHERE end_date < %s
-            ORDER BY end_date DESC
-            LIMIT 1
-        """, (event_date,))
-
-        previous_season = cursor.fetchone()
-        if previous_season:
-            print(
-                f"   📅 Event date {event_date} is after season '{previous_season['season_name']}' (ended {previous_season['end_date']})")
-            return previous_season['season_id']
-
-        # Event is before all seasons - check if there are any future seasons
-        cursor.execute("""
-            SELECT season_id, season_name, start_date, end_date
-            FROM seasons
-            WHERE start_date > %s
-            ORDER BY start_date ASC
-            LIMIT 1
-        """, (event_date,))
-
-        future_season = cursor.fetchone()
-        if future_season:
-            print(
-                f"   📅 Event date {event_date} is before all seasons (next season: '{future_season['season_name']}' starts {future_season['start_date']})")
-            return None  # Event is before any season exists
-
-        # No seasons exist at all
-        print(f"   📅 No seasons defined in system")
-        return None
-
-    except Exception as e:
-        print(f"   ❌ Error determining season for event date {event_date}: {str(e)}")
-        return None
-
-
-def can_delete_event(cursor, event_id, user_id, is_developer, is_admin):
-    """
-    Determine if a user can delete an event based on time-based rules.
-
-    Rules:
-    1. Developers can ALWAYS delete any event
-    2. Admins can delete ANY event within 24 hours of creation
-    3. GMs can delete their OWN events within 24 hours of creation
-    4. After 24 hours, only developers can delete
-
-    Args:
-        cursor: MySQL cursor
-        event_id: ID of the event
-        user_id: ID of the user attempting deletion
-        is_developer: Whether user is a developer
-        is_admin: Whether user is an admin
-
-    Returns:
-        tuple: (can_delete: bool, reason: str)
-    """
-    # Developers can always delete
-    if is_developer:
-        return (True, "Developer privileges")
-
-    # Fetch event creation info
-    cursor.execute("""
-        SELECT created_by, created_at
-        FROM generalevents
-        WHERE EventID = %s
-    """, (event_id,))
-
-    event = cursor.fetchone()
-
-    if not event:
-        return (False, "Event not found")
-
-    # Check if within 24-hour window
-    if not event['created_at']:
-        # If no creation timestamp, deny deletion (safety measure)
-        return (False, "Event creation time not recorded")
-
-    created_at = event['created_at']
-    current_time = datetime.now(EST)
-
-    # Ensure both datetimes are timezone-aware for comparison
-    if created_at.tzinfo is None:
-        created_at = localize_datetime(created_at)
-
-    time_since_creation = current_time - created_at
-    within_24_hours = time_since_creation <= timedelta(hours=24)
-
-    # Admins can delete ANY event within 24 hours
-    if is_admin:
-        if within_24_hours:
-            return (True, "Admin privileges - within 24-hour window")
-        else:
-            hours_ago = int(time_since_creation.total_seconds() / 3600)
-            return (False, f"Admin deletion window expired (created {hours_ago} hours ago)")
-
-    # GMs can only delete events THEY created within 24 hours
-    if event['created_by'] != user_id:
-        return (False, "Only the event creator, an admin (within 24h), or a developer can delete this event")
-
-    # User is the creator - check time window
-    if within_24_hours:
-        return (True, "Within 24-hour deletion window")
-    else:
-        hours_ago = int(time_since_creation.total_seconds() / 3600)
-        return (False, f"Deletion window expired (created {hours_ago} hours ago)")
 
 def register_event_routes(app, mysql, login_required, roles_required):
-    """
-    Register all event-related routes with the Flask app
+    """Register all event-related routes with the Flask app"""
 
-    Args:
-        app: Flask application instance
-        mysql: MySQL connection instance
-        login_required: Decorator for login protection
-        roles_required: Decorator for role-based access
-        get_user_permissions: Function to get user permissions
-    """
-
-    # ===================================
-    # EVENT CREATION
-    # ===================================
     @app.route('/event-register', methods=['GET', 'POST'])
     @roles_required('admin', 'gm', 'developer')
     def eventRegister():
-        """
-        Create a new event
-        NOW INCLUDES: created_at timestamp for deletion tracking
-        """
+        """Create a new event"""
         msg = ''
         if request.method == 'POST':
             eventName = request.form.get('eventName', '').strip()
@@ -195,11 +31,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
             if eventName and eventDate and eventType and startTime and endTime and eventDescription:
                 cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
                 try:
-                    import json
-
-                    print("\n" + "=" * 60)
-                    print(f"🎮 Creating Event: {eventName}")
-                    print("=" * 60)
 
                     selected_games = json.loads(games_json)
                     game_display = ', '.join(selected_games) if selected_games else None
@@ -227,7 +58,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
                          primary_game_id, session['id'], season_id, created_at))
 
                     event_id = cursor.lastrowid
-                    print(f"   ✅ Created event_id: {event_id} at {created_at}")
 
                     # Insert games into event_games table
                     if selected_games:
@@ -251,9 +81,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 except Exception as e:
                     mysql.connection.rollback()
                     msg = f'Error: {str(e)}'
-                    print(f"\n❌ EXCEPTION in eventRegister: {str(e)}")
-                    import traceback
-                    traceback.print_exc()
+                    print(f"\n EXCEPTION in eventRegister: {str(e)}")
 
                     if request.headers.get(
                             'X-Requested-With') == 'XMLHttpRequest' or request.accept_mimetypes.accept_json:
@@ -267,15 +95,11 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
         return render_template('event_register.html', msg=msg)
 
-    # ===================================
-    # EVENT RETRIEVAL
-    # ===================================
+
     @app.route('/api/events', methods=['GET'])
     @login_required
     def get_events():
-        """
-        Get events based on user role and filters
-        """
+        """Get events based on user role and filters"""
         try:
             user_id = session['id']
             cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
@@ -391,10 +215,12 @@ def register_event_routes(app, mysql, login_required, roles_required):
                         ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
                         ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
                         ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active
+                        s.season_name, s.is_active as season_is_active,
+                        t.teamName as team_name
                     FROM generalevents ge
                     LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
                     LEFT JOIN seasons s ON ge.season_id = s.season_id
+                    LEFT JOIN teams t ON se.team_id = t.TeamID
                     INNER JOIN event_subscriptions es ON ge.EventID = es.event_id
                     WHERE {where_clause} AND es.user_id = %s
                     AND {visibility_clause}
@@ -411,10 +237,12 @@ def register_event_routes(app, mysql, login_required, roles_required):
                         ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
                         ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
                         ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active
+                        s.season_name, s.is_active as season_is_active,
+                        t.teamName as team_name
                     FROM generalevents ge
                     LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
                     LEFT JOIN seasons s ON ge.season_id = s.season_id
+                    LEFT JOIN teams t ON se.team_id = t.TeamID
                     WHERE {where_clause}
                     AND {visibility_clause}
                     ORDER BY ge.Date {'ASC' if is_upcoming_filter else 'DESC'}, 
@@ -429,10 +257,12 @@ def register_event_routes(app, mysql, login_required, roles_required):
                         ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
                         ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
                         ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active
+                        s.season_name, s.is_active as season_is_active,
+                        t.teamName as team_name
                     FROM generalevents ge
                     LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
                     LEFT JOIN seasons s ON ge.season_id = s.season_id
+                    LEFT JOIN teams t ON se.team_id = t.TeamID
                     WHERE {where_clause}
                     AND {visibility_clause}
                     ORDER BY ge.Date {'ASC' if is_upcoming_filter else 'DESC'}, 
@@ -448,10 +278,12 @@ def register_event_routes(app, mysql, login_required, roles_required):
                         ge.EventID, ge.EventName, ge.Date, ge.StartTime, ge.EndTime,
                         ge.EventType, ge.Game, ge.Location, ge.Description, ge.created_by,
                         ge.is_scheduled, ge.schedule_id, ge.created_at,
-                        s.season_name, s.is_active as season_is_active
+                        s.season_name, s.is_active as season_is_active,
+                        t.teamName as team_name
                     FROM generalevents ge
                     LEFT JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
                     LEFT JOIN seasons s ON ge.season_id = s.season_id
+                    LEFT JOIN teams t ON se.team_id = t.TeamID
                     WHERE {where_clause}
                     AND {visibility_clause}
                     ORDER BY ge.Date {'ASC' if is_upcoming_filter else 'DESC'}, 
@@ -466,8 +298,8 @@ def register_event_routes(app, mysql, login_required, roles_required):
             # Process events
             events_list = []
             for event in events:
-                start_time_str = _format_time(event['StartTime'])
-                end_time_str = _format_time(event['EndTime'])
+                start_time_str = format_time_to_12hr(event['StartTime'])
+                end_time_str = format_time_to_12hr(event['EndTime'])
                 is_ongoing = _check_if_ongoing(event['Date'], start_time_str, end_time_str, current_date, current_time)
 
                 event_data = {
@@ -486,6 +318,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
                     'created_at': event['created_at'].isoformat() if event['created_at'] else None,
                     'is_scheduled': event.get('is_scheduled', False),
                     'schedule_id': event.get('schedule_id'),
+                    'team_name': event.get('team_name'),
                     'season_id': event.get('season_id'),
                     'season_name': event.get('season_name'),
                     'season_is_active': event.get('season_is_active', 0),
@@ -503,9 +336,8 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
         except Exception as e:
             print(f"Error fetching events: {str(e)}")
-            import traceback
-            traceback.print_exc()
             return jsonify({'success': False, 'message': 'Failed to fetch events'}), 500
+
 
     @app.route('/api/event/<int:event_id>')
     @login_required
@@ -513,7 +345,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
         """Get detailed information about a specific event"""
         cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
         try:
-            # ✅ UPDATED: Include league data
             cursor.execute("""
                 SELECT ge.*, 
                     s.season_name, 
@@ -536,8 +367,8 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 'name': event['EventName'],
                 'date': event['Date'].strftime('%B %d, %Y'),
                 'date_raw': event['Date'].strftime('%Y-%m-%d'),
-                'start_time': _format_time(event['StartTime']),
-                'end_time': _format_time(event['EndTime']),
+                'start_time': format_time_to_12hr(event['StartTime']),
+                'end_time': format_time_to_12hr(event['EndTime']),
                 'description': event['Description'] if event['Description'] else 'No description provided',
                 'event_type': event['EventType'] if event['EventType'] else 'General',
                 'game': event['Game'] if event['Game'] else 'N/A',
@@ -547,17 +378,15 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 'season_id': event.get('season_id'),
                 'season_name': event.get('season_name'),
                 'season_is_active': event.get('season_is_active', 0),
-                'league_id': event.get('league_id'),        # ✅ NEW
-                'league_name': event.get('league_name')     # ✅ NEW
+                'league_id': event.get('league_id'),
+                'league_name': event.get('league_name')
             }
 
             return jsonify(event_data)
         finally:
             cursor.close()
 
-    # ===================================
-    # EVENT EDITING
-    # ===================================
+
     @app.route('/api/event/edit', methods=['POST'])
     @login_required
     def edit_event():
@@ -613,7 +442,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
                 return jsonify({'success': False, 'message': 'You do not have permission to edit this event'}), 403
 
             # Parse games JSON
-            import json
             games_json = data.get('games', '[]')
             selected_games = json.loads(games_json) if isinstance(games_json, str) else games_json
 
@@ -637,9 +465,9 @@ def register_event_routes(app, mysql, login_required, roles_required):
             season_id = get_season_for_event_date(cursor, new_event_date)
 
             if season_id:
-                print(f"   📅 Updated event date {new_event_date} assigned to season_id: {season_id}")
+                print(f"   Updated event date {new_event_date} assigned to season_id: {season_id}")
             else:
-                print(f"   📅 Updated event date {new_event_date} has no season assignment")
+                print(f"   Updated event date {new_event_date} has no season assignment")
 
             # Update the event
             cursor.execute("""
@@ -685,22 +513,14 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
         except Exception as e:
             print(f"Error editing event: {str(e)}")
-            import traceback
-            traceback.print_exc()
             mysql.connection.rollback()
             return jsonify({'success': False, 'message': 'Failed to update event'}), 500
 
-    # ===================================
-    # EVENT DELETION
-    # ===================================
+
     @app.route('/api/events/<int:event_id>', methods=['DELETE'])
     @login_required
     def delete_event_from_tab(event_id):
-        """
-        Delete an event with time-based permissions
-        REFACTORED: 24-hour window for creators, always for developers
-        NOW INCLUDES: Automatic schedule cleanup when last event is deleted
-        """
+        """Delete an event with time-based permissions"""
         try:
             user_id = session['id']
             cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
@@ -781,22 +601,14 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
         except Exception as e:
             print(f"Error deleting event: {str(e)}")
-            import traceback
-            traceback.print_exc()
             mysql.connection.rollback()
             return jsonify({'success': False, 'message': 'Failed to delete event'}), 500
 
-    # ===================================
-    # EVENT DELETION (MODAL)
-    # ===================================
+
     @app.route('/delete-event', methods=['POST'])
     @login_required
     def delete_event_modal():
-        """
-        Delete an event from the modal view with time-based permissions
-        REFACTORED: 24-hour window for creators, always for developers
-        NOW INCLUDES: Automatic schedule cleanup when last event is deleted
-        """
+        """Delete an event from the modal view with time-based permissions"""
         try:
             user_id = session['id']
             data = request.get_json()
@@ -883,14 +695,10 @@ def register_event_routes(app, mysql, login_required, roles_required):
 
         except Exception as e:
             print(f"Error deleting event from modal: {str(e)}")
-            import traceback
-            traceback.print_exc()
             mysql.connection.rollback()
             return jsonify({'success': False, 'message': 'Failed to delete event'}), 500
 
-    # ===================================
-    # EVENT SUBSCRIPTIONS
-    # ===================================
+
     @app.route('/api/event/<int:event_id>/subscription-status')
     @login_required
     def subscription_status(event_id):
@@ -972,6 +780,7 @@ def register_event_routes(app, mysql, login_required, roles_required):
         finally:
             cursor.close()
 
+
     @app.route('/api/seasons/past', methods=['GET'])
     @login_required
     @roles_required('admin', 'developer')
@@ -1021,29 +830,6 @@ def register_event_routes(app, mysql, login_required, roles_required):
 # ===================================
 # HELPER FUNCTIONS
 # ===================================
-def _format_time(time_value):
-    """Convert timedelta or time object to 12-hour format string with AM/PM"""
-    if not time_value:
-        return None
-
-    if isinstance(time_value, timedelta):
-        total_seconds = int(time_value.total_seconds())
-        hours = total_seconds // 3600
-        minutes = (total_seconds % 3600) // 60
-    else:
-        # It's already a time object
-        hours = time_value.hour
-        minutes = time_value.minute
-
-    # Convert to 12-hour format
-    period = "AM" if hours < 12 else "PM"
-    display_hour = hours % 12
-    if display_hour == 0:
-        display_hour = 12
-
-    return f"{display_hour}:{minutes:02d} {period}"
-
-
 def _check_if_ongoing(event_date, start_time_str, end_time_str, current_date, current_time):
     """Check if an event is currently ongoing"""
     if event_date != current_date or not start_time_str or not end_time_str:
@@ -1061,3 +847,127 @@ def _check_if_ongoing(event_date, start_time_str, end_time_str, current_date, cu
     except Exception as e:
         print(f"Error checking if event is ongoing: {str(e)}")
         return False
+
+
+def get_season_for_event_date(cursor, event_date):
+    """
+    Determine which season an event belongs to based on its date.
+
+    Logic:
+    1. If event falls within an active or past season's date range, use that season
+    2. If event is before all seasons, return None
+    3. If event is between seasons, assign to the most recent previous season
+    4. If event is after all seasons, assign to the most recent season
+    """
+    # Convert string to date if needed
+    if isinstance(event_date, str):
+        event_date = datetime.strptime(event_date, '%Y-%m-%d').date()
+
+    try:
+        # Check if event falls within any season's date range
+        cursor.execute("""
+            SELECT season_id, season_name, start_date, end_date
+            FROM seasons
+            WHERE %s BETWEEN start_date AND end_date
+            ORDER BY start_date DESC
+            LIMIT 1
+        """, (event_date,))
+
+        direct_match = cursor.fetchone()
+        if direct_match:
+            return direct_match['season_id']
+
+        # Event doesn't fall within any season - find the most recent previous season
+        cursor.execute("""
+            SELECT season_id, season_name, start_date, end_date
+            FROM seasons
+            WHERE end_date < %s
+            ORDER BY end_date DESC
+            LIMIT 1
+        """, (event_date,))
+
+        previous_season = cursor.fetchone()
+        if previous_season:
+            return previous_season['season_id']
+
+        # Event is before all seasons - check if there are any future seasons
+        cursor.execute("""
+            SELECT season_id, season_name, start_date, end_date
+            FROM seasons
+            WHERE start_date > %s
+            ORDER BY start_date ASC
+            LIMIT 1
+        """, (event_date,))
+
+        future_season = cursor.fetchone()
+        if future_season:
+            return None  # Event is before any season exists
+
+        # No seasons exist at all
+        print(f"  No seasons defined in system")
+        return None
+
+    except Exception as e:
+        print(f"  Error determining season for event date {event_date}: {str(e)}")
+        return None
+
+
+def can_delete_event(cursor, event_id, user_id, is_developer, is_admin):
+    """
+    Determine if a user can delete an event based on time-based rules.
+
+    Rules:
+    1. Developers can ALWAYS delete any event
+    2. Admins can delete ANY event within 24 hours of creation
+    3. GMs can delete their OWN events within 24 hours of creation
+    4. After 24 hours, only developers can delete
+    """
+    # Developers can always delete
+    if is_developer:
+        return (True, "Developer privileges")
+
+    # Fetch event creation info
+    cursor.execute("""
+        SELECT created_by, created_at
+        FROM generalevents
+        WHERE EventID = %s
+    """, (event_id,))
+
+    event = cursor.fetchone()
+
+    if not event:
+        return (False, "Event not found")
+
+    # Check if within 24-hour window
+    if not event['created_at']:
+        # If no creation timestamp, deny deletion (safety measure)
+        return (False, "Event creation time not recorded")
+
+    created_at = event['created_at']
+    current_time = datetime.now(EST)
+
+    # Ensure both datetimes are timezone-aware for comparison
+    if created_at.tzinfo is None:
+        created_at = localize_datetime(created_at)
+
+    time_since_creation = current_time - created_at
+    within_24_hours = time_since_creation <= timedelta(hours=24)
+
+    # Admins can delete ANY event within 24 hours
+    if is_admin:
+        if within_24_hours:
+            return (True, "Admin privileges - within 24-hour window")
+        else:
+            hours_ago = int(time_since_creation.total_seconds() / 3600)
+            return (False, f"Admin deletion window expired (created {hours_ago} hours ago)")
+
+    # GMs can only delete events THEY created within 24 hours
+    if event['created_by'] != user_id:
+        return (False, "Only the event creator, an admin (within 24h), or a developer can delete this event")
+
+    # User is the creator - check time window
+    if within_24_hours:
+        return (True, "Within 24-hour deletion window")
+    else:
+        hours_ago = int(time_since_creation.total_seconds() / 3600)
+        return (False, f"Deletion window expired (created {hours_ago} hours ago)")

--- a/EsportsManagementTool/EsportsManagementTool/events.py
+++ b/EsportsManagementTool/EsportsManagementTool/events.py
@@ -389,6 +389,35 @@ def register_event_routes(app, mysql, login_required, roles_required):
         finally:
             cursor.close()
 
+    @app.route('/api/event/<int:event_id>/games')
+    @login_required
+    def api_event_games(event_id):
+        """Get game IDs and banners for an event via event_games table"""
+        cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+        try:
+            cursor.execute("""
+                SELECT g.GameID, g.GameTitle, g.Abbreviation, g.GameBanner
+                FROM event_games eg
+                JOIN games g ON eg.game_id = g.GameID
+                WHERE eg.event_id = %s
+            """, (event_id,))
+            games = cursor.fetchall()
+
+            # Fallback: scheduled events use se.game_id directly
+            if not games:
+                cursor.execute("""
+                    SELECT g.GameID, g.GameTitle, g.Abbreviation, g.GameBanner
+                    FROM generalevents ge
+                    JOIN scheduled_events se ON ge.schedule_id = se.schedule_id
+                    JOIN games g ON se.game_id = g.GameID
+                    WHERE ge.EventID = %s
+                """, (event_id,))
+                games = cursor.fetchall()
+
+            return jsonify({'success': True, 'games': games or []})
+        finally:
+            cursor.close()
+
 
     @app.route('/api/event/edit', methods=['POST'])
     @login_required

--- a/EsportsManagementTool/EsportsManagementTool/static/calendar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/calendar.js
@@ -79,7 +79,7 @@ function handleDynamicReposition() {
     'closeChangePasswordModal',
     'closeDeleteConfirmModal',
     'closeAddTeamMembersModal',
-    'closeCreateScheduledEventModal',
+    'closeCreateScheduleModal',
     'closeAddVodModal'
 ].forEach(function(name) {
     if (typeof window[name] !== 'function') {
@@ -409,7 +409,6 @@ function displayEventDetails(event) {
     html += `
         <div class="event-detail-row">
             <div class="event-detail-icon"><i class="fas fa-calendar"></i></div>
-            <span class="event-detail-label">Date:</span>
             <span class="event-detail-value">${formatEventDate(event.date)}</span>
         </div>
     `;
@@ -419,7 +418,6 @@ function displayEventDetails(event) {
         html += `
             <div class="event-detail-row">
                 <div class="event-detail-icon"><i class="fas fa-clock"></i></div>
-                <span class="event-detail-label">Time:</span>
                 <span class="event-detail-value">${formatTime(event.start_time)} - ${formatTime(event.end_time)}</span>
             </div>
         `;
@@ -427,7 +425,6 @@ function displayEventDetails(event) {
         html += `
             <div class="event-detail-row">
                 <div class="event-detail-icon"><i class="fas fa-clock"></i></div>
-                <span class="event-detail-label">Time:</span>
                 <span class="event-detail-value">All day</span>
             </div>
         `;
@@ -437,7 +434,6 @@ function displayEventDetails(event) {
     html += `
         <div class="event-detail-row">
             <div class="event-detail-icon"><i class="fas fa-tag"></i></div>
-            <span class="event-detail-label">Type:</span>
             <span class="event-detail-value">
                 <span class="event-type-badge" data-type="${eventType}">${capitalizeFirst(event.event_type || 'Event')}</span>
             </span>
@@ -448,7 +444,6 @@ function displayEventDetails(event) {
     html += `
         <div class="event-detail-row">
             <div class="event-detail-icon"><i class="fas fa-gamepad"></i></div>
-            <span class="event-detail-label">Game:</span>
             <span class="event-detail-value">${event.game_name || 'General'}</span>
         </div>
     `;
@@ -458,7 +453,6 @@ function displayEventDetails(event) {
         html += `
             <div class="event-detail-row">
                 <div class="event-detail-icon"><i class="fas fa-map-marker-alt"></i></div>
-                <span class="event-detail-label">Location:</span>
                 <span class="event-detail-value">${event.location}</span>
             </div>
         `;
@@ -469,7 +463,6 @@ function displayEventDetails(event) {
         html += `
             <div class="event-detail-row">
                 <div class="event-detail-icon"><i class="fas fa-info-circle"></i></div>
-                <span class="event-detail-label">Description:</span>
                 <span class="event-detail-value">${event.description}</span>
             </div>
         `;
@@ -642,17 +635,17 @@ function displayEventPopupDetails(data, popup, clickedElement){
 
                 <div class="popup-row">
                     <span class="popup-icon"><i class="fas fa-tag"></i></span>
-                    <span class="popup-text" style="text-transform: capitalize;">Event Type: ${data.event_type}</span>
+                    <span class="popup-text" style="text-transform: capitalize;">${data.event_type}</span>
                 </div>
 
                 <div class="popup-games-box">
                     <span class="popup-icon"><i class="fas fa-gamepad"></i></span>
-                    <span class="popup-text">Game: ${data.game_name || 'N/A'}</span>
+                    <span class="popup-text">${data.game_name || 'N/A'}</span>
                 </div>
 
                 <div class="popup-row full-width">
                     <span class="popup-icon"><i class="fas fa-map-marker-alt"></i></span>
-                    <span class="popup-text">Location: ${data.location || 'Online'}</span>
+                    <span class="popup-text">${data.location || 'Online'}</span>
                 </div>
             </div>
 
@@ -799,62 +792,56 @@ function capitalizeFirst(str) {
 async function loadNotificationSection(eventId) {
     const btn = document.getElementById('notificationBtn');
     const btnText = document.getElementById('notificationBtnText');
+    const panelBtn = document.getElementById('detailSubscribeBtn');
+    const panelBtnText = document.getElementById('detailSubscribeBtnText');
 
-    if (!btn || !btnText) return;
+    // At least one must exist to be worth fetching
+    if (!btn && !panelBtn) return;
 
     try {
         const response = await fetch(`/api/event/${eventId}/subscription-status`);
         const data = await response.json();
 
         if (!data.notifications_enabled) {
-            btn.disabled = true;
-            btn.classList.add('disabled');
-            btnText.textContent = 'Enable notifications in Profile';
+            [btn, panelBtn].forEach(b => { if (b) { b.disabled = true; b.classList.add('disabled'); } });
+            [btnText, panelBtnText].forEach(t => { if (t) t.textContent = 'Enable notifications in Profile'; });
             return;
         }
 
-        btn.disabled = false;
-        btn.classList.remove('disabled');
-
-        if (data.subscribed) {
-            btnText.textContent = 'Subscribed';
-            btn.classList.add('subscribed');
-        } else {
-            btnText.textContent = 'Subscribe';
-            btn.classList.remove('subscribed');
-        }
+        const isSubscribed = data.subscribed;
+        [btn, panelBtn].forEach(b => {
+            if (!b) return;
+            b.disabled = false;
+            b.classList.remove('disabled');
+            b.classList.toggle('subscribed', isSubscribed);
+        });
+        [btnText, panelBtnText].forEach(t => { if (t) t.textContent = isSubscribed ? 'Subscribed' : 'Subscribe'; });
 
     } catch (err) {
         console.error('Error fetching subscription status:', err);
-        btn.disabled = true;
-        btnText.textContent = 'Error';
+        [btn, panelBtn].forEach(b => { if (b) b.disabled = true; });
+        [btnText, panelBtnText].forEach(t => { if (t) t.textContent = 'Error'; });
     }
 }
 
 async function toggleEventSubscription() {
     const btn = document.getElementById('notificationBtn');
     const btnText = document.getElementById('notificationBtnText');
+    const panelBtn = document.getElementById('detailSubscribeBtn');
+    const panelBtnText = document.getElementById('detailSubscribeBtnText');
 
-    if (!window.currentEventId) return;
+    if (!window.currentEventId && !EventState.currentEventId) return;
+    const eventId = window.currentEventId || EventState.currentEventId;
 
     try {
-        const response = await fetch(`/api/event/${window.currentEventId}/toggle-subscription`, {
-            method: 'POST'
-        });
+        const response = await fetch(`/api/event/${eventId}/toggle-subscription`, { method: 'POST' });
         const data = await response.json();
 
-        if (data.error) {
-            alert(data.error);
-            return;
-        }
+        if (data.error) { alert(data.error); return; }
 
-        if (data.status === 'subscribed') {
-            btnText.textContent = 'Subscribed';
-            btn.classList.add('subscribed');
-        } else {
-            btnText.textContent = 'Subscribe';
-            btn.classList.remove('subscribed');
-        }
+        const isSubscribed = data.status === 'subscribed';
+        [btn, panelBtn].forEach(b => { if (b) b.classList.toggle('subscribed', isSubscribed); });
+        [btnText, panelBtnText].forEach(t => { if (t) t.textContent = isSubscribed ? 'Subscribed' : 'Subscribe'; });
 
     } catch (err) {
         console.error('Error toggling subscription:', err);

--- a/EsportsManagementTool/EsportsManagementTool/static/calendar.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/calendar.js
@@ -786,6 +786,63 @@ function capitalizeFirst(str) {
 }
 
 // ============================================
+// DAY MODAL (CALENDAR VIEW)
+// ============================================
+function openDayModal(date, dateTitle) {
+    const modal = document.getElementById('dayEventsModal');
+    const modalTitle = document.getElementById('modalDayTitle');
+    const modalBody = document.getElementById('modalEventsList');
+
+    modalTitle.textContent = dateTitle;
+    const events = EventState.eventsData[date] || [];
+
+    // Clear and populate modal body
+    modalBody.innerHTML = '';
+
+    if (events.length > 0) {
+        events.forEach(event => {
+            const eventItem = createDayModalEventItem(event);
+            modalBody.appendChild(eventItem);
+        });
+    } else {
+        modalBody.innerHTML = '<p style="color: var(--text-secondary); text-align: center;">No events scheduled for this day.</p>';
+    }
+
+    setElementDisplay(modal, 'block');
+    document.body.style.overflow = 'hidden';
+}
+
+// Create event item for day modal
+function createDayModalEventItem(event) {
+    const eventItem = document.createElement('div');
+    eventItem.className = 'modal-event-item';
+    eventItem.onclick = (e) => {
+        e.stopPropagation();
+        closeDayModal();
+        openEventModal(event.id);
+    };
+
+    let eventHTML = '';
+    if (event.time) {
+        eventHTML += `<div class="modal-event-time"><i class="fas fa-clock"></i> ${event.time}</div>`;
+    }
+    eventHTML += `<div class="modal-event-title">${event.title}</div>`;
+    if (event.description) {
+        eventHTML += `<div class="modal-event-description">${event.description}</div>`;
+    }
+
+    eventItem.innerHTML = eventHTML;
+    return eventItem;
+}
+
+// Close day modal
+function closeDayModal() {
+    const modal = document.getElementById('dayEventsModal');
+    setElementDisplay(modal, 'none');
+    document.body.style.overflow = 'auto';
+}
+
+// ============================================
 // EVENT SUBSCRIPTION FUNCTIONS
 // ============================================
 
@@ -869,6 +926,8 @@ function closeDayModal() { window.closeDayModal(); }
 function closeEventPopup() { window.closeEventPopup(); }
 
 window.openCalendarEventModal = openCalendarEventModal;
+window.openDayModal = openDayModal;
+window.closeDayModal = closeDayModal;
 
 if (typeof window.openEventModal !== 'function') {
     window.openEventModal = openCalendarEventModal;

--- a/EsportsManagementTool/EsportsManagementTool/static/communities.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/communities.css
@@ -564,6 +564,7 @@
     align-items: center;
     gap: 0.4rem;
     transition: all 0.2s;
+    cursor: pointer;
 }
 
 .member-list-popup {

--- a/EsportsManagementTool/EsportsManagementTool/static/communities.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/communities.js
@@ -743,7 +743,7 @@ async function loadNextCommunityEvent(gameId) {
 
             // Format event card
             container.innerHTML = `
-                <div class="game-next-event-card" onclick="openEventModal(${event.id})">
+                <div class="game-next-event-card" onclick="navigateToEvent(${event.id})">
                     <div class="game-next-event-header">
                         <i class="fas fa-calendar-plus"></i>
                         <h4>Next Community Event</h4>

--- a/EsportsManagementTool/EsportsManagementTool/static/dashboard-base.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/dashboard-base.css
@@ -72,9 +72,9 @@ main {
     margin-bottom: 1.5rem;
     padding-bottom: 1rem;
     border-bottom: 1px solid var(--border-color);
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
 }
 
 .card-header h2 {

--- a/EsportsManagementTool/EsportsManagementTool/static/dashboard-base.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/dashboard-base.css
@@ -1,7 +1,6 @@
 /* ============================================
    DASHBOARD BASE STYLES
    Core stylesheet for dashboard layout
-   ORGANIZED BY CLAUDEAI
    ============================================ */
 
 /* --------------------------------------------
@@ -76,13 +75,10 @@ main {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    /*align-items: flex-start;*/
-    /*flex-wrap: wrap;*/
 }
 
 .card-header h2 {
     font-size: 1.5rem;
-    margin-bottom: 0.25rem;
 }
 
 .card-header p {
@@ -176,16 +172,11 @@ main {
 @media (max-width: 1038px) {
   .card-header {
     flex-direction: column;
-    /*gap: 1rem;*/
   }
 
   .card-header .btn {
     width: 100%;
   }
-
-  /*.card-header p {*/
-  /*    display: none;*/
-  /*}*/
 
   .dashboard-header {
     display: none;

--- a/EsportsManagementTool/EsportsManagementTool/static/events.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.css
@@ -112,14 +112,12 @@
     min-width: 0;
     padding-right: 1.25rem;
     padding-top: 0.15rem;
-    max-height: calc(100vh - 260px);
     overflow-y: auto;
     scrollbar-gutter: stable;
+    max-height: calc(100vh - 260px);
 }
 
 .events-detail-pane {
-    position: sticky;
-    top: 1rem;
     align-self: stretch;
     min-height: 480px;
     border-left: 1px solid var(--border-color);
@@ -195,20 +193,23 @@
 }
 
 .events-detail-banner-btn {
-    background: transparent;
-    border: none;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
     color: var(--stockton-blue);
-    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.6875rem;
     cursor: pointer;
     transition: all 0.2s;
-    font-size: 0.875rem;
-    border-radius: 6px;
-    opacity: 1;
 }
 
 .events-detail-banner-btn:hover {
     background: rgba(121, 189, 233, 0.15);
-    color: var(--stockton-blue);
+    border-color: #1fc1f2;
 }
 
 .events-detail-banner-btn:active {
@@ -216,12 +217,13 @@
 }
 
 .events-detail-banner-btn.delete {
-    color: var(--event-match);
+    color: #ef4444;
+    transition: background 0.2s, border-color 0.2s;
 }
 
 .events-detail-banner-btn.delete:hover {
-    background: var(--event-match-light);
-    color: var(--event-match);
+    background: rgba(239, 68, 68, 0.1);
+    border-color: #ef4444;
 }
 
 .events-detail-title {
@@ -274,6 +276,55 @@
     margin: 0;
 }
 
+/* Edit Mode */
+.panel-edit-input {
+    background: var(--hover-bg);
+    border: 1px solid var(--stockton-blue);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    padding: 0.3rem 0.5rem;
+    width: 100%;
+    outline: none;
+    font-family: inherit;
+}
+
+.panel-edit-input:focus {
+    box-shadow: 0 0 0 2px rgba(121, 189, 233, 0.2);
+}
+
+textarea.panel-edit-input {
+    resize: vertical;
+    min-height: 64px;
+}
+
+.panel-edit-time-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.panel-edit-time-row .panel-edit-input {
+    width: auto;
+    flex: 1;
+}
+
+.events-detail-title.panel-edit-input {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    width: 100%;
+}
+
+.panel-save-btn {
+    color: var(--event-practice) !important;
+}
+
+.panel-edit-input-error {
+    border-color: var(--event-match) !important;
+    box-shadow: 0 0 0 2px var(--event-match-light);
+}
+
 /* ===============================
    Event Cards
    =============================== */
@@ -281,6 +332,8 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 1.25rem;
+    align-items: start;
+    min-height: 100%;
 }
 
 .event-card {

--- a/EsportsManagementTool/EsportsManagementTool/static/events.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.css
@@ -1,29 +1,14 @@
 /* ============================================
-   EVENTS TAB STYLES
-   Event management and display interface
-   ORGANIZED BY CLAUDEAI
+   EVENTS RELATED STYLES
+   - Event cards
+   - Event pills and colors
+   - Event tab structure
+   - Calendar pills
    ============================================ */
 
-/* --------------------------------------------
-   CARD HEADER LAYOUT
-   Header section with filters and actions
-   -------------------------------------------- */
-#events .card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 2rem;
-}
-
-#events .card-header > div:first-child {
-    flex: 0 1 auto;
-}
-
-/* --------------------------------------------
+/* =============================
    EVENT FILTER DROPDOWN
-   Dropdown for filtering events by type
-   -------------------------------------------- */
-/* Main header controls wrapper - keeps filters and button together */
+   ============================= */
 .event-header-controls {
     display: flex;
     flex-direction: column;
@@ -34,7 +19,6 @@
     padding-right: 140px;
 }
 
-/* Filters container - stacks filter rows vertically */
 .event-filters-container {
     display: grid;
     grid-template-columns: auto auto ;
@@ -91,7 +75,6 @@
     box-shadow: 0 0 0 3px rgba(121, 189, 233, 0.1);
 }
 
-/* Loading indicators */
 .event-filter-dropdown > div[id$="LoadingIndicator"] {
     display: inline-flex;
     align-items: center;
@@ -116,59 +99,259 @@
     top: 1px;
 }
 
-/* --------------------------------------------
-   EVENTS GRID LAYOUT
-   Grid container for event cards
-   -------------------------------------------- */
-.events-grid {
+/* ==============================
+   Events Tab Layout
+   ============================== */
+.events-layout {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 1.5rem;
-    margin-top: 2rem;
+    grid-template-columns: 1fr 420px;
+    align-items: start;
 }
 
-/* --------------------------------------------
-   EVENT CARDS
-   Individual event display cards
-   -------------------------------------------- */
+.events-list-pane {
+    min-width: 0;
+    padding-right: 1.25rem;
+    padding-top: 0.15rem;
+    max-height: calc(100vh - 260px);
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+}
+
+.events-detail-pane {
+    position: sticky;
+    top: 1rem;
+    align-self: stretch;
+    min-height: 480px;
+    border-left: 1px solid var(--border-color);
+    padding-left: 2rem;
+}
+
+/* ===================================
+   Event Details Sidebar
+   =================================== */
+.events-detail-placeholder {
+    height: 100%;
+    min-height: 460px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 0.75rem;
+    color: var(--text-secondary);
+    border: 1px dashed var(--border-color);
+    border-radius: 12px;
+    padding: 2rem;
+}
+
+.events-detail-placeholder i {
+    font-size: 2.25rem;
+    opacity: 0.35;
+}
+
+.events-detail-placeholder p {
+    font-size: 0.9375rem;
+    max-width: 220px;
+    margin: 0;
+}
+
+/* Panel shown when an event is selected */
+.events-detail-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.events-detail-banner-wrapper {
+    position: relative;
+    margin-bottom: 1.25rem;
+}
+
+.events-detail-banner {
+    width: 100%;
+    height: 70px;
+    background: var(--hover-bg);
+    border: 1px dashed var(--border-color);
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    flex-shrink: 0;
+}
+
+.events-detail-banner-actions {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: flex;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.events-detail-panel:hover .events-detail-banner-actions {
+    opacity: 1;
+}
+
+.events-detail-banner-btn {
+    background: transparent;
+    border: none;
+    color: var(--stockton-blue);
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-size: 0.875rem;
+    border-radius: 6px;
+    opacity: 1;
+}
+
+.events-detail-banner-btn:hover {
+    background: rgba(121, 189, 233, 0.15);
+    color: var(--stockton-blue);
+}
+
+.events-detail-banner-btn:active {
+    transform: scale(0.95);
+}
+
+.events-detail-banner-btn.delete {
+    color: var(--event-match);
+}
+
+.events-detail-banner-btn.delete:hover {
+    background: var(--event-match-light);
+    color: var(--event-match);
+}
+
+.events-detail-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 0.25rem 0;
+}
+
+.events-detail-type-badge {
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+.events-detail-pane .notification-opt-in .subtitle {
+    font-size: 0.7rem;
+}
+
+.events-detail-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+    margin-bottom: 1.5rem;
+}
+
+.events-detail-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+}
+
+.events-detail-row .event-detail-icon {
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+}
+
+.events-detail-row-text h4 {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin: 0 0 0.1rem 0;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.events-detail-row-text p {
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+/* ===============================
+   Event Cards
+   =============================== */
+.events-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1.25rem;
+}
+
 .event-card {
     background: var(--dark-bg);
     border: 1px solid var(--border-color);
-    border-radius: 12px;
-    padding: 1.5rem;
-    transition: all 0.3s;
-    position: relative;
-    overflow: hidden;
+    border-left: 3px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.875rem 1rem;
+    transition: all 0.2s ease;
     cursor: pointer;
 }
 
 .event-card:hover {
-    transform: translateY(-4px);
+    transform: translateY(-3px);
     border-color: var(--stockton-blue);
     box-shadow: 0 8px 16px rgba(121, 189, 233, 0.1);
 }
 
-/* Event card header */
-.event-card-header {
+.event-card-top {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+}
+
+.event-card-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.event-card-game {
+    flex: 0 0 auto;
+    max-width: 45%;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.event-card-bottom {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-    margin-bottom: 1rem;
+    align-items: center;
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
 }
 
-.event-card-title {
-    flex: 1;
-    margin: 0;
+.event-card-date i {
+    margin-right: 0.35rem;
+    opacity: 0.7;
+    width: 12px;
 }
 
-/* Ongoing event indicator */
+.event-card-time {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+}
+
+/* Ongoing event indicator - top-left corner dot */
 .event-ongoing-indicator {
     position: absolute;
-    top: -0.5rem;
-    right: -0.5rem;
-    width: 12px;
-    height: 12px;
+    top: -4px;
+    left: -4px;
+    width: 10px;
+    height: 10px;
     background: #4ade80;
     border-radius: 50%;
     border: 2px solid var(--dark-bg);
@@ -176,55 +359,38 @@
     z-index: 10;
 }
 
-/* --------------------------------------------
-   EVENT CARD DETAILS
-   Date, time, and game information display
-   -------------------------------------------- */
-.event-card-details {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-bottom: 1.25rem;
-}
-
-.event-detail-row {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 0.875rem;
-}
-
-.event-detail-icon {
-    width: 40px;
-    height: 40px;
-    background: rgba(121, 189, 233, 0.1);
-    border-radius: 8px;
+/* Delete button - icon only, revealed on card hover */
+.event-card-delete-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 24px;
+    height: 24px;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--stockton-blue);
-    flex-shrink: 0;
-    font-size: 1.125rem;
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: #ef4444;
+    font-size: 0.6875rem;
+    opacity: 0;
+    transition: opacity 0.2s, background 0.2s, border-color 0.2s;
+    cursor: pointer;
 }
 
-.event-detail-label {
-    font-weight: 500;
-    color: var(--text-secondary);
-    min-width: 80px;
+.event-card:hover .event-card-delete-btn {
+    opacity: 1;
 }
 
-.event-detail-value {
-    color: var(--text-primary);
-    flex: 1;
+.event-card-delete-btn:hover {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: #ef4444;
 }
 
 /* ============================================
    DELETION TIME INDICATORS
-   NEW: Shows time remaining for deletion window
-   Add these styles to events.css
    ============================================ */
-
-/* Deletion time remaining badge */
 .deletion-time-remaining {
     display: inline-flex;
     align-items: center;
@@ -242,18 +408,11 @@
     font-size: 0.625rem;
 }
 
-/* When inside a delete button, use transparent background */
-.btn-delete .deletion-time-remaining {
-    background: transparent;
-}
-
-/* Time remaining in delete button (inline style) */
 .btn-delete span {
     font-size: 0.75rem;
     opacity: 0.9;
 }
 
-/* Delete confirmation modal - time warning box */
 .delete-confirmation-time-warning {
     margin-top: 1rem;
     padding: 0.75rem;
@@ -278,94 +437,37 @@
     margin-left: 0.25rem;
 }
 
-/* --------------------------------------------
-   EVENT TYPE BADGES
-   Color-coded type indicators
-   -------------------------------------------- */
-.event-type-badge {
-    display: inline-block;
-    padding: 0.35rem 0.85rem;
-    border-radius: 6px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    background: transparent !important;
+/* ============================================
+   Event Card Type Color Accent
+   ============================================ */
+.event-card[data-event-type="tournament"],
+.event-card.tournament {
+    border-left-color: var(--event-tournament);
 }
 
-/* Tournament - Purple Border */
-.event-type-badge[data-type="tournament"],
-.event-type-badge.tournament {
-    border: 1px solid rgba(167, 139, 250, 1) !important;
-    color: rgba(167, 139, 250, 1) !important;
+.event-card[data-event-type="match"],
+.event-card.match {
+    border-left-color: var(--event-match);
 }
 
-/* Match - Red Border */
-.event-type-badge[data-type="match"],
-.event-type-badge.match {
-    border: 1px solid rgba(255, 28, 47, 1) !important;
-    color: rgba(255, 28, 47, 1) !important;
+.event-card[data-event-type="practice"],
+.event-card.practice {
+    border-left-color: var(--event-practice);
 }
 
-/* Practice - Green Border */
-.event-type-badge[data-type="practice"],
-.event-type-badge.practice {
-    border: 1px solid rgba(134, 239, 172, 1) !important;
-    color: rgba(134, 239, 172, 1) !important;
+.event-card[data-event-type="event"],
+.event-card.event {
+    border-left-color: var(--event-event);
 }
 
-/* Event - Blue Border */
-.event-type-badge[data-type="event"],
-.event-type-badge.event {
-    border: 1px solid rgba(147, 197, 253, 1) !important;
-    color: rgba(147, 197, 253, 1) !important;
+.event-card[data-event-type="misc"],
+.event-card.misc {
+    border-left-color: var(--event-misc);
 }
 
-/* Misc - Yellow Border */
-.event-type-badge[data-type="misc"],
-.event-type-badge.misc {
-    border: 1px solid rgba(250, 204, 21, 1) !important;
-    color: rgba(250, 204, 21, 1) !important;
-}
-
-/* --------------------------------------------
-   EVENT TYPE COLORS - CARD ICONS
-   Icon background colors by event type
-   -------------------------------------------- */
-.event-card[data-event-type="tournament"] .event-detail-icon,
-.event-card.tournament .event-detail-icon {
-    background: var(--event-tournament-light);
-    color: var(--event-tournament);
-}
-
-.event-card[data-event-type="match"] .event-detail-icon,
-.event-card.match .event-detail-icon {
-    background: var(--event-match-light);
-    color: var(--event-match);
-}
-
-.event-card[data-event-type="practice"] .event-detail-icon,
-.event-card.practice .event-detail-icon {
-    background: var(--event-practice-light);
-    color: var(--event-practice);
-}
-
-.event-card[data-event-type="event"] .event-detail-icon,
-.event-card.event .event-detail-icon {
-    background: var(--event-event-light);
-    color: var(--event-event);
-}
-
-.event-card[data-event-type="misc"] .event-detail-icon,
-.event-card.misc .event-detail-icon {
-    background: var(--event-misc-light);
-    color: var(--event-misc);
-}
-
-/* --------------------------------------------
-   EVENT TYPE COLORS - CARD BORDERS
-   Border colors on hover by event type
-   -------------------------------------------- */
+/* ===============================================
+   Event Card Hover Borders
+   =============================================== */
 .event-card[data-event-type="tournament"]:hover,
 .event-card.tournament:hover {
     border-color: var(--event-tournament);
@@ -391,154 +493,63 @@
     border-color: var(--event-misc);
 }
 
-/* --------------------------------------------
-   SCHEDULED EVENT STYLING
-   Special styling for scheduled events
-   -------------------------------------------- */
+/* Scheduled event specific colors */
 .event-card.scheduled-event:hover {
-    border: 2px solid white !important;
+    border: 2px solid white;
     box-shadow: 0 8px 16px rgba(255, 255, 255, 0.3);
 }
 
 .event-card.scheduled-event .event-type-badge {
-    border: 2px solid white !important;
+    border: 2px solid white;
     box-shadow: 0 0 2px rgba(255, 255, 255, 0.2);
 }
 
-/* --------------------------------------------
-   EVENT CARD ACTIONS
-   Action buttons at bottom of cards
-   -------------------------------------------- */
-.event-card-actions {
-    display: flex;
-    gap: 0.75rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border-color);
-}
-
-.event-card-actions .btn {
-    flex: 0.5;
-    font-size: 0.875rem;
-    padding: 0.625rem 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    border-radius: 6px;
-    font-weight: 500;
-    transition: all 0.2s;
-    cursor: pointer;
-}
-
-.event-card-actions .btn-primary {
-    background: var(--stockton-blue);
-    color: var(--stockton-black);
-    border: none;
-}
-
-.event-card-actions .btn-primary:hover {
-    background: #5aabdd;
-    transform: translateY(-1px);
-}
-
-.event-card-actions .btn-secondary {
-    background: transparent;
-    color: var(--text-secondary);
-    border: 1px solid var(--border-color);
-}
-
-.event-card-actions .btn-secondary:hover {
-    background: var(--hover-bg);
-    color: var(--text-primary);
-    border-color: var(--stockton-blue);
-}
-
-.event-card-actions .btn-delete {
-    background: transparent;
-    color: #ef4444;
-    border: 1px solid #ef4444;
-}
-
-.event-card-actions .btn-delete:hover {
-    background: rgba(239, 68, 68, 0.1);
-    transform: translateY(-1px);
-}
-
-/* --------------------------------------------
-   MODAL - EVENT DETAILS
-   Event detail modal icon colors
-   -------------------------------------------- */
+/* ==============================================
+   Event Details Modal Colors
+   ============================================== */
 #eventDetailsModal {
     z-index: 10002;
 }
+
 .modal-content[data-event-type="tournament"] .event-detail-icon,
-#eventDetailsModal[data-event-type="tournament"] .event-detail-icon {
+#eventDetailsModal[data-event-type="tournament"] .event-detail-icon,
+.events-detail-panel[data-event-type="tournament"] .event-detail-icon {
     background: var(--event-tournament-light);
     color: var(--event-tournament);
 }
 
 .modal-content[data-event-type="match"] .event-detail-icon,
-#eventDetailsModal[data-event-type="match"] .event-detail-icon {
+#eventDetailsModal[data-event-type="match"] .event-detail-icon,
+.events-detail-panel[data-event-type="match"] .event-detail-icon {
     background: var(--event-match-light);
     color: var(--event-match);
 }
 
 .modal-content[data-event-type="practice"] .event-detail-icon,
-#eventDetailsModal[data-event-type="practice"] .event-detail-icon {
+#eventDetailsModal[data-event-type="practice"] .event-detail-icon,
+.events-detail-panel[data-event-type="practice"] .event-detail-icon {
     background: var(--event-practice-light);
     color: var(--event-practice);
 }
 
 .modal-content[data-event-type="event"] .event-detail-icon,
-#eventDetailsModal[data-event-type="event"] .event-detail-icon {
+#eventDetailsModal[data-event-type="event"] .event-detail-icon,
+.events-detail-panel[data-event-type="event"] .event-detail-icon {
     background: var(--event-event-light);
     color: var(--event-event);
 }
 
 .modal-content[data-event-type="misc"] .event-detail-icon,
-#eventDetailsModal[data-event-type="misc"] .event-detail-icon {
+#eventDetailsModal[data-event-type="misc"] .event-detail-icon,
+.events-detail-panel[data-event-type="misc"] .event-detail-icon {
     background: var(--event-misc-light);
     color: var(--event-misc);
 }
 
-/* --------------------------------------------
-   FILTER BUTTONS
-   Alternative filter button style
-   -------------------------------------------- */
-.events-filter {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
-}
-
-.filter-button {
-    padding: 0.5rem 1rem;
-    background: transparent;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    color: var(--text-secondary);
-    font-size: 0.875rem;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.filter-button:hover {
-    background: var(--hover-bg);
-    color: var(--text-primary);
-}
-
-.filter-button.active {
-    background: var(--stockton-blue);
-    color: var(--stockton-black);
-    border-color: var(--stockton-blue);
-}
-
-/* -------------------------------------------
-    MULTI-GAME SELECTION
-    Select Multiple games from a dropdown
-    ------------------------------------------ */
-/* Multi-select game dropdown */
+/* ===========================================
+    Create Event Modal
+   =========================================== */
+/* Select multiple games from dropdown */
 select[multiple] {
     padding: 0.5rem;
     background: var(--dark-bg);
@@ -655,10 +666,7 @@ select[multiple]:focus {
     pointer-events: auto !important;
 }
 
-/* --------------------------------------------
-   ALL DAY EVENT TOGGLE
-   Toggle button for all-day events
-   -------------------------------------------- */
+/* All day event toggle */
 .all-day-toggle-btn {
     padding: 0.5rem 1rem;
     background-color: var(--stockton-blue);
@@ -686,10 +694,7 @@ select[multiple]:focus {
     box-shadow: 0 0 8px rgba(76, 175, 80, 0.3);
 }
 
-/* --------------------------------------------
-   INFO MESSAGES
-   Informational message banners
-   -------------------------------------------- */
+/* Submission information messages */
 .events-info-message {
     background: rgba(121, 189, 233, 0.1);
     border: 1px solid var(--stockton-blue);
@@ -712,10 +717,7 @@ select[multiple]:focus {
     font-size: 0.875rem;
 }
 
-/* --------------------------------------------
-   EMPTY STATE
-   Display when no events exist
-   -------------------------------------------- */
+/* Events empty state */
 .events-empty-state {
     text-align: center;
     padding: 4rem 2rem;
@@ -738,10 +740,7 @@ select[multiple]:focus {
     font-size: 1rem;
 }
 
-/* --------------------------------------------
-   LOADING STATE
-   Display while fetching events
-   -------------------------------------------- */
+/* Events loading state */
 .events-loading {
     text-align: center;
     padding: 4rem 2rem;
@@ -758,10 +757,9 @@ select[multiple]:focus {
     font-size: 1rem;
 }
 
-/* --------------------------------------------
-   ANIMATIONS
-   Keyframe animations
-   -------------------------------------------- */
+/* ===============================
+   Animations
+   =============================== */
 @keyframes pulse {
     0%, 100% {
         opacity: 1;
@@ -773,10 +771,9 @@ select[multiple]:focus {
     }
 }
 
-/* --------------------------------------------
-   RESPONSIVE DESIGN
-   Mobile and tablet adaptations
-   -------------------------------------------- */
+/* ================================
+   Mobile Friendliness
+   ================================ */
 @media (max-width: 1400px) {
     .event-filter-row {
         flex-wrap: wrap;
@@ -807,15 +804,40 @@ select[multiple]:focus {
     #events .card-header > div:last-child {
         grid-template-columns: 1fr;
     }
+
+    .events-layout {
+        grid-template-columns: 1fr 340px;
+    }
+
+    .events-list-pane {
+        padding-right: 1.5rem;
+    }
+
+    .events-detail-pane {
+        padding-left: 1.5rem;
+    }
 }
 
 @media (max-width: 768px) {
-    .events-grid {
+    .events-layout {
         grid-template-columns: 1fr;
+        gap: 2rem;
     }
 
-    .event-card-actions {
-        flex-direction: column;
+    .events-list-pane {
+        padding-right: 0;
+    }
+
+    .events-detail-pane {
+        position: static;
+        border-left: none;
+        padding-left: 0;
+        border-top: 1px solid var(--border-color);
+        padding-top: 2rem;
+    }
+
+    .events-grid {
+        grid-template-columns: 1fr;
     }
 
     .event-header-controls {

--- a/EsportsManagementTool/EsportsManagementTool/static/events.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.css
@@ -11,16 +11,16 @@
    ============================================ */
 .event-header-controls {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 1rem;
-    flex: 0 1 auto;
-    position: relative;
-    padding-right: 50px;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+    justify-content: flex-end;
 }
 
 .event-filters-container {
     display: flex;
+    flex-shrink: 0;
     gap: 0.2rem;
     align-items: center;
     flex-wrap: wrap;
@@ -132,6 +132,17 @@
     background: transparent;
 }
 
+/* Bridge for left side popout */
+.filter-box-item--flyout::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 100%;
+    width: 0.75rem;
+    height: 100%;
+    background: transparent;
+}
+
 .filter-box-item--flyout:hover .filter-box-flyout {
     display: block;
 }
@@ -161,14 +172,13 @@
     color: var(--text-secondary);
 }
 
-/* Create Event Button - smaller, on first row */
+/* Create Event Button */
 .event-header-controls > .btn-primary {
     flex-shrink: 0;
     white-space: nowrap;
     padding: 0.5rem 1rem;
     font-size: 0.875rem;
-    position: absolute;
-    right: 0;
+    position: static;
 }
 
 /* ==============================
@@ -235,6 +245,7 @@
 .events-detail-banner-wrapper {
     position: relative;
     margin-bottom: 1.25rem;
+    min-height: 0;
 }
 
 .events-detail-banner {
@@ -275,8 +286,9 @@
 .events-detail-banner-actions {
     position: absolute;
     top: 0.5rem;
-    right: 0.5rem;
+    right: 0;
     display: flex;
+    gap: 0.4rem;
     opacity: 0;
     transition: opacity 0.2s;
 }
@@ -920,35 +932,42 @@ select[multiple]:focus {
 /* ================================
    Mobile Friendliness
    ================================ */
-@media (max-width: 1400px) {
-    .event-filter-row {
-        flex-wrap: wrap;
-    }
-}
+
 
 @media (max-width: 1200px) {
-    #events .card-header {
-        flex-direction: column;
-        align-items: flex-start;
+    #events .card-header > div:first-child p {
+        grid-template-columns: 1fr;
     }
 
     .event-header-controls {
         width: 100%;
-        padding-right: 0;
-        position: static;
+        flex-wrap: nowrap;
+        gap: 0.5rem;
     }
 
     .event-header-controls > .btn-primary {
-        position: static;
-        width: 100%;
-        margin-top: 0.75rem;
+        white-space: nowrap;
+        width: auto;
+        padding: 0.45rem 0.75rem;
     }
 }
 
 /* Tablet: Stack to single column */
 @media (max-width: 1024px) {
-    #events .card-header > div:last-child {
+    #events .card-header > div:first-child p {
         grid-template-columns: 1fr;
+    }
+
+    .event-header-controls {
+        width: 100%;
+        flex-wrap: nowrap;
+        gap: 0.5rem;
+    }
+
+    .event-header-controls > .btn-primary {
+        white-space: nowrap;
+        width: auto;
+        padding: 0.45rem 0.75rem;
     }
 
     .events-layout {
@@ -965,60 +984,198 @@ select[multiple]:focus {
 }
 
 @media (max-width: 768px) {
+    /* --- Header --- */
+    #events .card-header {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+    }
+
+    #events .card-header > div:first-child p {
+        display: none;
+    }
+
+    .event-header-controls {
+        width: 100%;
+        flex-wrap: nowrap;
+        justify-content: space-between;
+        gap: 0.5rem;
+    }
+
+    .event-filters-container {
+        flex: 0 0 auto;
+    }
+
+    .event-header-controls > .btn-primary {
+        white-space: nowrap;
+        flex: 0 0 auto;
+        width: auto;
+        padding: 0.45rem 0.75rem;
+    }
+
+    /* --- Cards --- */
     .events-layout {
         grid-template-columns: 1fr;
-        gap: 2rem;
     }
 
     .events-list-pane {
         padding-right: 0;
-    }
-
-    .events-detail-pane {
-        position: static;
-        border-left: none;
-        padding-left: 0;
-        border-top: 1px solid var(--border-color);
-        padding-top: 2rem;
-    }
-
-    .events-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .event-header-controls {
-        flex-direction: column;
-        width: 100%;
-        align-items: stretch;
-    }
-
-    .event-filter-row {
-        flex-direction: column;
-        align-items: flex-start;
-        width: 100%;
-    }
-
-    .event-filter-dropdown {
-        width: 100%;
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .event-filter-dropdown select {
+        max-height: none;
+        overflow-x: hidden;
         width: 100%;
         min-width: 0;
     }
 
-    .event-header-controls > .btn-primary {
+    .events-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.5rem;
+        min-width: 0;
         width: 100%;
     }
 
+    .event-card {
+        min-width: 0;
+        height: 90px;
+        width: 100%;
+        padding: 0.5rem 0.6rem;
+    }
+
+    .event-card-top {
+        min-width: 0;
+        height: 35px;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.15rem;
+    }
+
+    .event-card-name {
+        font-size: 0.75rem;
+        max-width: 100%;
+    }
+
+    .event-card-game {
+        font-size: 0.65rem;
+        margin-left: 0;
+        text-align: left;
+        color: var(--text-secondary);
+    }
+
+    .event-card-bottom {
+        font-size: 0.7rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.1rem;
+    }
+
+    .event-card-time {
+        font-size: 0.7rem;
+    }
+
+    /* --- Detail panel becomes a bottom sheet --- */
+    .events-detail-pane {
+        display: none; /* hidden by default, JS toggles open */
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 78vh;
+        border-left: none;
+        border-top: 1px solid var(--border-color);
+        border-radius: 16px 16px 0 0;
+        background: var(--card-bg);
+        padding: 1rem 1.25rem 1.5rem;
+        z-index: 500;
+        overflow-y: auto;
+        box-shadow: 0 -8px 32px rgba(0,0,0,0.4);
+        transform: translateY(100%);
+        transition: transform 0.3s ease;
+    }
+
+    .events-detail-pane.sheet-open {
+        display: block;
+        transform: translateY(0);
+    }
+
+    /* Drag handle */
+    .events-detail-pane::before {
+        content: '';
+        display: block;
+        width: 40px;
+        height: 4px;
+        background: var(--border-color);
+        border-radius: 2px;
+        margin: 0 auto 1rem;
+    }
+
+    /* Backdrop */
+    .sheet-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.5);
+        z-index: 499;
+    }
+
+    .sheet-backdrop.open {
+        display: block;
+    }
+
+    /* --- Filter flyouts become stacked within the panel on mobile --- */
+    .filter-box-item--flyout .filter-box-flyout {
+        position: static;
+        display: none;
+        box-shadow: none;
+        border: none;
+        border-radius: 10px;
+        padding: 0 0 0 1rem;
+        max-height: none;
+    }
+
+    .filter-box-item--flyout:hover .filter-box-flyout {
+        display: none;
+    }
+
+    .filter-box-item--flyout.flyout-expanded .filter-box-flyout {
+        display: block;
+    }
+
+    .filter-box-item--flyout::after,
+    .filter-box-item--flyout::before {
+        display: none;
+    }
+
+    .filter-box-item--flyout > i.fa-chevron-right {
+        transition: transform 0.2s;
+    }
+
+    .filter-box-item--flyout.flyout-expanded > i.fa-chevron-right {
+        transform: rotate(90deg);
+    }
+
+    .filter-box-panel {
+        position: fixed !important;
+        top: auto !important;
+        bottom: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        border-radius: 16px 16px 0 0;
+        padding: 1rem 0.5rem 2rem;
+        max-height: 60vh;
+        overflow-y: auto;
+        z-index: 600;
+        box-shadow: 0 -8px 32px rgba(0,0,0,0.4);
+    }
+
+    /* Misc */
     .deletion-time-remaining {
         font-size: 0.7rem;
         padding: 0.1rem 0.3rem;
     }
 
     .btn-delete span {
-        display: none; /* Hide time on mobile, show icon only */
+        display: none;
     }
 }

--- a/EsportsManagementTool/EsportsManagementTool/static/events.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.css
@@ -1,185 +1,11 @@
 /* ============================================
-   EVENTS RELATED STYLES
+   EVENTS TAB STYLES
    - Event cards
-   - Event pills and colors
+   - Event Type Colors
    - Event tab structure
-   - Calendar pills
+   - Filter structure
+   - Mobile View
    ============================================ */
-
-/* ============================================
-   FILTER BOXES
-   ============================================ */
-.event-header-controls {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.75rem;
-    flex-shrink: 0;
-    justify-content: flex-end;
-}
-
-.event-filters-container {
-    display: flex;
-    flex-shrink: 0;
-    gap: 0.2rem;
-    align-items: center;
-    flex-wrap: wrap;
-}
-
-.filter-box {
-    position: relative;
-}
-
-.filter-box-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.45rem 0.875rem;
-    background: var(--dark-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    color: var(--text-primary);
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-    white-space: nowrap;
-}
-
-.filter-box-btn:hover,
-.filter-box-btn.active {
-    border-color: var(--stockton-blue);
-    background: var(--hover-bg);
-}
-
-.filter-box-btn i {
-    font-size: 0.7rem;
-    color: var(--text-secondary);
-    transition: transform 0.2s;
-}
-
-.filter-box-btn.active i {
-    transform: rotate(180deg);
-}
-
-.filter-box-panel {
-    display: none;
-    position: absolute;
-    top: calc(100% + 0.4rem);
-    left: 0;
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
-    padding: 0.375rem;
-    min-width: 180px;
-    z-index: 200;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
-}
-
-.filter-box-panel.open {
-    display: block;
-}
-
-.filter-box-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.5rem 0.75rem;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    color: var(--text-primary);
-    cursor: pointer;
-    position: relative;
-    transition: background 0.15s;
-    white-space: nowrap;
-}
-
-.filter-box-item:hover {
-    background: var(--hover-bg);
-}
-
-.filter-box-item i {
-    font-size: 0.7rem;
-    color: var(--text-secondary);
-}
-
-/* Flyout submenu */
-.filter-box-item--flyout .filter-box-flyout {
-    display: none;
-    position: absolute;
-    top: -0.375rem;
-    left: calc(100% + 0.375rem);
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
-    padding: 0.375rem;
-    min-width: 160px;
-    z-index: 201;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
-    max-height: 210px;
-    overflow-y: auto;
-}
-
-/* Transparent bridge fills the gap between item and flyout so
-   the mouse doesn't leave the hover zone while crossing */
-.filter-box-item--flyout::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 100%;
-    width: 0.75rem;
-    height: 100%;
-    background: transparent;
-}
-
-/* Bridge for left side popout */
-.filter-box-item--flyout::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 100%;
-    width: 0.75rem;
-    height: 100%;
-    background: transparent;
-}
-
-.filter-box-item--flyout:hover .filter-box-flyout {
-    display: block;
-}
-
-.filter-box-item--flyout .filter-box-flyout.flyout-left {
-    left: auto;
-    right: calc(100% + 0.375rem);
-}
-
-.filter-box-flyout-item {
-    padding: 0.5rem 0.75rem;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    color: var(--text-primary);
-    cursor: pointer;
-    transition: background 0.15s;
-    white-space: nowrap;
-}
-
-.filter-box-flyout-item:hover {
-    background: var(--hover-bg);
-}
-
-.filter-box-flyout-loading {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8125rem;
-    color: var(--text-secondary);
-}
-
-/* Create Event Button */
-.event-header-controls > .btn-primary {
-    flex-shrink: 0;
-    white-space: nowrap;
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    position: static;
-}
 
 /* ==============================
    Events Tab Layout
@@ -204,6 +30,15 @@
     min-height: 480px;
     border-left: 1px solid var(--border-color);
     padding-left: 2rem;
+}
+
+/* Create Event Button */
+.event-header-controls > .btn-primary {
+    flex-shrink: 0;
+    white-space: nowrap;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    position: static;
 }
 
 /* ===================================
@@ -517,87 +352,10 @@ textarea.panel-edit-input {
     z-index: 10;
 }
 
-/* Delete button - icon only, revealed on card hover */
-.event-card-delete-btn {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--dark-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    color: #ef4444;
-    font-size: 0.6875rem;
-    opacity: 0;
-    transition: opacity 0.2s, background 0.2s, border-color 0.2s;
-    cursor: pointer;
-}
-
-.event-card:hover .event-card-delete-btn {
-    opacity: 1;
-}
-
-.event-card-delete-btn:hover {
-    background: rgba(239, 68, 68, 0.1);
-    border-color: #ef4444;
-}
-
 /* ============================================
-   DELETION TIME INDICATORS
+   Event Type Colors
    ============================================ */
-.deletion-time-remaining {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    color: #fbbf24;
-    margin-left: 0.25rem;
-    padding: 0.125rem 0.375rem;
-    background: rgba(251, 191, 36, 0.1);
-    border-radius: 4px;
-    white-space: nowrap;
-}
-
-.deletion-time-remaining i {
-    font-size: 0.625rem;
-}
-
-.btn-delete span {
-    font-size: 0.75rem;
-    opacity: 0.9;
-}
-
-.delete-confirmation-time-warning {
-    margin-top: 1rem;
-    padding: 0.75rem;
-    background: rgba(251, 191, 36, 0.1);
-    border: 1px solid #fbbf24;
-    border-radius: 6px;
-    font-size: 0.875rem;
-}
-
-.delete-confirmation-time-warning i {
-    color: #fbbf24;
-    margin-right: 0.5rem;
-}
-
-.delete-confirmation-time-warning strong {
-    color: #fbbf24;
-}
-
-/* Icon button adjustments for time display */
-.btn-icon-delete span {
-    font-size: 0.7rem;
-    margin-left: 0.25rem;
-}
-
-/* ============================================
-   Event Card Type Color Accent
-   ============================================ */
+/* Event card accent */
 .event-card[data-event-type="tournament"],
 .event-card.tournament {
     border-left-color: var(--event-tournament);
@@ -623,9 +381,7 @@ textarea.panel-edit-input {
     border-left-color: var(--event-misc);
 }
 
-/* ===============================================
-   Event Card Hover Borders
-   =============================================== */
+/* Event Card Hover Border */
 .event-card[data-event-type="tournament"]:hover,
 .event-card.tournament:hover {
     border-color: var(--event-tournament);
@@ -662,43 +418,27 @@ textarea.panel-edit-input {
     box-shadow: 0 0 2px rgba(255, 255, 255, 0.2);
 }
 
-/* ==============================================
-   Event Details Modal Colors
-   ============================================== */
-#eventDetailsModal {
-    z-index: 10002;
-}
-
-.modal-content[data-event-type="tournament"] .event-detail-icon,
-#eventDetailsModal[data-event-type="tournament"] .event-detail-icon,
+/* Event Detail Panel Icons */
 .events-detail-panel[data-event-type="tournament"] .event-detail-icon {
     background: var(--event-tournament-light);
     color: var(--event-tournament);
 }
 
-.modal-content[data-event-type="match"] .event-detail-icon,
-#eventDetailsModal[data-event-type="match"] .event-detail-icon,
 .events-detail-panel[data-event-type="match"] .event-detail-icon {
     background: var(--event-match-light);
     color: var(--event-match);
 }
 
-.modal-content[data-event-type="practice"] .event-detail-icon,
-#eventDetailsModal[data-event-type="practice"] .event-detail-icon,
 .events-detail-panel[data-event-type="practice"] .event-detail-icon {
     background: var(--event-practice-light);
     color: var(--event-practice);
 }
 
-.modal-content[data-event-type="event"] .event-detail-icon,
-#eventDetailsModal[data-event-type="event"] .event-detail-icon,
 .events-detail-panel[data-event-type="event"] .event-detail-icon {
     background: var(--event-event-light);
     color: var(--event-event);
 }
 
-.modal-content[data-event-type="misc"] .event-detail-icon,
-#eventDetailsModal[data-event-type="misc"] .event-detail-icon,
 .events-detail-panel[data-event-type="misc"] .event-detail-icon {
     background: var(--event-misc-light);
     color: var(--event-misc);
@@ -915,6 +655,172 @@ select[multiple]:focus {
     font-size: 1rem;
 }
 
+/* ============================================
+   FILTER BOXES
+   ============================================ */
+.event-header-controls {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+    justify-content: flex-end;
+}
+
+.event-filters-container {
+    display: flex;
+    flex-shrink: 0;
+    gap: 0.2rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.filter-box {
+    position: relative;
+}
+
+.filter-box-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0.875rem;
+    background: var(--dark-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.filter-box-btn:hover,
+.filter-box-btn.active {
+    border-color: var(--stockton-blue);
+    background: var(--hover-bg);
+}
+
+.filter-box-btn i {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    transition: transform 0.2s;
+}
+
+.filter-box-btn.active i {
+    transform: rotate(180deg);
+}
+
+.filter-box-panel {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    left: 0;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.375rem;
+    min-width: 180px;
+    z-index: 200;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+}
+
+.filter-box-panel.open {
+    display: block;
+}
+
+.filter-box-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    position: relative;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+
+.filter-box-item:hover {
+    background: var(--hover-bg);
+}
+
+.filter-box-item i {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+}
+
+/* Flyout submenu */
+.filter-box-item--flyout .filter-box-flyout {
+    display: none;
+    position: absolute;
+    top: -0.375rem;
+    left: calc(100% + 0.375rem);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.375rem;
+    min-width: 160px;
+    z-index: 201;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    max-height: 210px;
+    overflow-y: auto;
+}
+
+/* Transparent bridge fills the gap between item and flyout so
+   the mouse doesn't leave the hover zone while crossing */
+.filter-box-item--flyout::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 100%;
+    width: 0.75rem;
+    height: 100%;
+    background: transparent;
+}
+
+/* Bridge for left side popout */
+.filter-box-item--flyout::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 100%;
+    width: 0.75rem;
+    height: 100%;
+    background: transparent;
+}
+
+.filter-box-item--flyout:hover .filter-box-flyout {
+    display: block;
+}
+
+.filter-box-item--flyout .filter-box-flyout.flyout-left {
+    left: auto;
+    right: calc(100% + 0.375rem);
+}
+
+.filter-box-flyout-item {
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+
+.filter-box-flyout-item:hover {
+    background: var(--hover-bg);
+}
+
+.filter-box-flyout-loading {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+}
+
 /* ===============================
    Animations
    =============================== */
@@ -932,8 +838,6 @@ select[multiple]:focus {
 /* ================================
    Mobile Friendliness
    ================================ */
-
-
 @media (max-width: 1200px) {
     #events .card-header > div:first-child p {
         grid-template-columns: 1fr;

--- a/EsportsManagementTool/EsportsManagementTool/static/events.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.css
@@ -116,7 +116,7 @@
     min-width: 160px;
     z-index: 201;
     box-shadow: 0 8px 24px rgba(0,0,0,0.3);
-    max-height: 205px;
+    max-height: 210px;
     overflow-y: auto;
 }
 
@@ -134,6 +134,11 @@
 
 .filter-box-item--flyout:hover .filter-box-flyout {
     display: block;
+}
+
+.filter-box-item--flyout .filter-box-flyout.flyout-left {
+    left: auto;
+    right: calc(100% + 0.375rem);
 }
 
 .filter-box-flyout-item {

--- a/EsportsManagementTool/EsportsManagementTool/static/events.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.css
@@ -6,9 +6,9 @@
    - Calendar pills
    ============================================ */
 
-/* =============================
-   EVENT FILTER DROPDOWN
-   ============================= */
+/* ============================================
+   FILTER BOXES
+   ============================================ */
 .event-header-controls {
     display: flex;
     flex-direction: column;
@@ -16,76 +16,144 @@
     gap: 1rem;
     flex: 0 1 auto;
     position: relative;
-    padding-right: 140px;
+    padding-right: 50px;
 }
 
 .event-filters-container {
-    display: grid;
-    grid-template-columns: auto auto ;
-    gap: 0.75rem;
-    align-items: end;
+    display: flex;
+    gap: 0.2rem;
+    align-items: center;
+    flex-wrap: wrap;
 }
 
-/* Only add padding when second column has content */
-.event-filters-container[data-columns="2"] {
-    padding-right: 1rem;
+.filter-box {
+    position: relative;
 }
 
-/* Individual filter dropdown */
-.event-filter-dropdown {
+.filter-box-btn {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-}
-
-#pastSeasonSelectContainer {
-    grid-column: 1;
-    grid-row: 2;
-}
-
-.event-filter-dropdown label {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    white-space: nowrap;
-    margin: 0;
-    min-width: 60px;
-    text-align: right;
-}
-
-.event-filter-dropdown select {
-    padding: 0.5rem 1rem;
+    padding: 0.45rem 0.875rem;
     background: var(--dark-bg);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: 8px;
     color: var(--text-primary);
     font-size: 0.875rem;
+    font-weight: 500;
     cursor: pointer;
     transition: all 0.2s;
-    min-width: 180px;
+    white-space: nowrap;
 }
 
-.event-filter-dropdown select:hover {
+.filter-box-btn:hover,
+.filter-box-btn.active {
     border-color: var(--stockton-blue);
     background: var(--hover-bg);
 }
 
-.event-filter-dropdown select:focus {
-    outline: none;
-    border-color: var(--stockton-blue);
-    box-shadow: 0 0 0 3px rgba(121, 189, 233, 0.1);
+.filter-box-btn i {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    transition: transform 0.2s;
 }
 
-.event-filter-dropdown > div[id$="LoadingIndicator"] {
-    display: inline-flex;
+.filter-box-btn.active i {
+    transform: rotate(180deg);
+}
+
+.filter-box-panel {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    left: 0;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.375rem;
+    min-width: 180px;
+    z-index: 200;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+}
+
+.filter-box-panel.open {
+    display: block;
+}
+
+.filter-box-item {
+    display: flex;
     align-items: center;
-    gap: 0.5rem;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    position: relative;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+
+.filter-box-item:hover {
+    background: var(--hover-bg);
+}
+
+.filter-box-item i {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+}
+
+/* Flyout submenu */
+.filter-box-item--flyout .filter-box-flyout {
+    display: none;
+    position: absolute;
+    top: -0.375rem;
+    left: calc(100% + 0.375rem);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.375rem;
+    min-width: 160px;
+    z-index: 201;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    max-height: 205px;
+    overflow-y: auto;
+}
+
+/* Transparent bridge fills the gap between item and flyout so
+   the mouse doesn't leave the hover zone while crossing */
+.filter-box-item--flyout::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 100%;
+    width: 0.75rem;
+    height: 100%;
+    background: transparent;
+}
+
+.filter-box-item--flyout:hover .filter-box-flyout {
+    display: block;
+}
+
+.filter-box-flyout-item {
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+
+.filter-box-flyout-item:hover {
+    background: var(--hover-bg);
+}
+
+.filter-box-flyout-loading {
+    padding: 0.5rem 0.75rem;
     font-size: 0.8125rem;
     color: var(--text-secondary);
-    margin-left: 0.5rem;
-}
-
-.event-filter-dropdown > div[id$="LoadingIndicator"] i {
-    font-size: 0.75rem;
 }
 
 /* Create Event Button - smaller, on first row */
@@ -96,7 +164,6 @@
     font-size: 0.875rem;
     position: absolute;
     right: 0;
-    top: 1px;
 }
 
 /* ==============================
@@ -177,6 +244,27 @@
     color: var(--text-secondary);
     font-size: 0.8125rem;
     flex-shrink: 0;
+    position: relative;
+    overflow: hidden;
+}
+
+.event-detail-banner-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 10px;
+    opacity: 0.8;
+}
+
+.event-detail-banner-slide {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    transition: opacity 1s ease-in-out;
+}
+
+.event-detail-banner-slide.active {
+    opacity: 0.8;
 }
 
 .events-detail-banner-actions {
@@ -208,7 +296,7 @@
 }
 
 .events-detail-banner-btn:hover {
-    background: rgba(121, 189, 233, 0.15);
+    background: var(--dark-bg);;
     border-color: #1fc1f2;
 }
 
@@ -222,7 +310,7 @@
 }
 
 .events-detail-banner-btn.delete:hover {
-    background: rgba(239, 68, 68, 0.1);
+    background: var(--dark-bg);;
     border-color: #ef4444;
 }
 

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -2,10 +2,14 @@
  * ============================================
  * events.js
  * ============================================
+ *
  * Handles all general event-related functionality
- * - event loading
- * - filtering events in the events tab
  * - CRUD operations for events
+ * - Event card and event detail pane display
+ * - Event filter system with flyout cards
+ * - Mobile event tab compatibility
+ * - Dynamic game dropdown construction
+ * - Create event modal
  */
 
 // ============================================
@@ -121,10 +125,10 @@ function attachEventListeners() {
 }
 
 // ============================================
-// API & DATA LOADING
+// Event Loading
 // ============================================
 
-// Load events from server based on filtering criteria
+// Load events based on filter criteria
 function loadEvents() {
     const elements = {
         loading: document.getElementById('eventsLoading'),
@@ -132,10 +136,8 @@ function loadEvents() {
         emptyState: document.getElementById('eventsEmptyState')
     };
 
-    // Show loading state
-    setElementDisplay(elements.loading, 'block');
-    setElementDisplay(elements.container, 'none');
-    setElementDisplay(elements.emptyState, 'none');
+    //Show loading for events
+    showEventsLoadingState()
 
     // Build query parameters
     const queryParams = buildEventFilterParams();
@@ -159,7 +161,7 @@ function loadEvents() {
             showEventsError();
         })
         .finally(() => {
-            setElementDisplay(elements.loading, 'none');
+            hideEventsLoadingState();
         });
 
         // Check if we were redirected here to view a specific event
@@ -192,6 +194,871 @@ function loadEvents() {
             setTimeout(() => tryOpen(), 200);
         }
 }
+
+// Load events for selected past season with filters
+function loadEventsForPastSeason() {
+    if (!PastSeasonFilterState.selectedSeasonId) {
+        console.warn('No past season selected');
+        return;
+    }
+
+    const elements = {
+        loading: document.getElementById('eventsLoading'),
+        container: document.getElementById('eventsContainer'),
+        emptyState: document.getElementById('eventsEmptyState')
+    };
+
+    // Show loading state
+    showEventsLoadingState();
+
+    // Build query parameters
+    let queryParams = `season_id=${PastSeasonFilterState.selectedSeasonId}`;
+
+    // Add secondary filter
+    const secondaryFilter = PastSeasonFilterState.secondaryFilter;
+
+    if (secondaryFilter === 'created_by_me') {
+        queryParams += '&filter=created_by_me';
+    } else if (secondaryFilter === 'type') {
+        const typeFilter = document.getElementById('eventTypeFilter')?.value;
+        if (typeFilter) {
+            queryParams += `&filter=type&event_type=${typeFilter}`;
+        }
+    } else if (secondaryFilter === 'game') {
+        const gameFilter = PastSeasonFilterState.selectedGame || document.getElementById('gameFilter')?.value;
+        if (gameFilter) {
+            queryParams += `&filter=game&game=${encodeURIComponent(gameFilter)}`;
+        }
+    } else {
+        // "all" - just use season filter
+        queryParams += '&filter=all';
+    }
+
+    // Fetch events
+    fetch(`/api/events?${queryParams}`)
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                EventState.setPermissions(data.is_admin, data.is_developer, data.is_gm);
+                renderEvents(data.events, data.is_admin, data.is_developer, data.is_gm);
+
+                // Update empty state message for season filtering
+                updateEmptyStateMessage()
+            } else {
+                console.error('Failed to load events:', data.message);
+                showEventsError();
+            }
+        })
+        .catch(error => {
+            console.error('Error loading events:', error);
+            showEventsError();
+        })
+        .finally(() => {
+            hideEventsLoadingState();
+        });
+}
+
+// Builds structure for event tab display
+function renderEvents(events, isAdmin, isGm) {
+    const containerDiv = document.getElementById('eventsContainer');
+    const emptyStateDiv = document.getElementById('eventsEmptyState');
+
+    if (events.length === 0) {
+        setElementDisplay(containerDiv, 'none');
+        setElementDisplay(emptyStateDiv, 'block');
+        updateEmptyStateMessage();
+        return;
+    }
+
+    const gridHTML = `<div class="events-grid">${
+        events.map(event => createEventCard(event, isAdmin, isGm)).join('')
+    }</div>`;
+
+    containerDiv.innerHTML = gridHTML;
+    setElementDisplay(containerDiv, 'grid');
+
+    // Open detail panel on card click (not the modal)
+    containerDiv.querySelectorAll('.event-card').forEach(card => {
+        card.addEventListener('click', (e) => {
+            openEventDetailPanel(parseInt(card.dataset.eventId));
+        });
+    });
+
+    // Dynamically match list pane scroll height to detail pane
+    const detailPane = document.getElementById('eventsDetailPane');
+    const listPane = document.querySelector('.events-list-pane');
+    if (detailPane && listPane) {
+        if (window._detailPaneObserver) window._detailPaneObserver.disconnect();
+        window._detailPaneObserver = new ResizeObserver(() => {
+            listPane.style.maxHeight = '';
+            const detailHeight = detailPane.offsetHeight;
+            const cap = window.innerHeight - 260;
+            listPane.style.maxHeight = Math.max(detailHeight, cap) + 'px';
+        });
+        window._detailPaneObserver.observe(detailPane);
+    }
+
+    setElementDisplay(containerDiv, 'block');
+    setElementDisplay(emptyStateDiv, 'none');
+}
+
+// Builds individual event cards
+function createEventCard(event, isAdmin, isGm) {
+    const canDelete = canUserDeleteEvent(event);
+    const ongoingIndicator = event.is_ongoing
+        ? '<div class="event-ongoing-indicator" title="Event is currently ongoing"></div>'
+        : '';
+
+    const gameDisplay = formatGameDisplay(event.game, event.team_name, event.is_scheduled);
+    const eventTypeClass = (event.event_type || 'event').toLowerCase();
+    const scheduledClass = event.is_scheduled ? 'scheduled-event' : '';
+    const timeDisplay = event.start_time ? event.start_time : '';
+
+    return `
+        <div class="event-card ${scheduledClass}" data-event-type="${eventTypeClass}" data-event-id="${event.id}" ...>
+            ${ongoingIndicator}
+            <div class="event-card-top">
+                <span class="event-card-name">${event.name}</span>
+                <span class="event-card-game">${gameDisplay}</span>
+            </div>
+            <div class="event-card-bottom">
+                <span class="event-card-date"><i class="fas fa-calendar"></i>${event.date}</span>
+                ${timeDisplay ? `<span class="event-card-time">${timeDisplay}</span>` : ''}
+            </div>
+        </div>
+    `;
+}
+
+// Look up a game's abbreviation from the cached games list
+function getGameAbbreviation(title) {
+    const game = EventState.gamesListCache?.find(g => g.GameTitle === title);
+    return game?.Abbreviation || title; // fall back to full title if not found/not loaded yet
+}
+
+// Format game display: first game's abbreviation, plus a count of any others
+function formatGameDisplay(gameStr, teamName, isScheduled) {
+    if (isScheduled && teamName) return teamName;
+    if (!gameStr || gameStr === 'N/A') return '';
+
+    const games = gameStr.split(', ').map(getGameAbbreviation);
+    return games.length > 1 ? `${games[0]} +${games.length - 1}` : games[0];
+}
+
+// Show error state when events fail to load
+function showEventsError() {
+    const containerDiv = document.getElementById('eventsContainer');
+    if (!containerDiv) return;
+
+    containerDiv.innerHTML = `
+        <div class="events-info-message">
+            <i class="fas fa-exclamation-circle"></i>
+            <p>Failed to load events. Please refresh the page to try again.</p>
+        </div>
+    `;
+    setElementDisplay(containerDiv, 'block');
+}
+
+/* =================================
+   Create Event
+   ================================= */
+function openCreateEventModal() {
+    const modal = document.getElementById('createEventModal');
+    const form = document.getElementById('createEventForm');
+    const customLocationGroup = document.getElementById('customLocationGroup');
+    const formMessage = document.getElementById('formMessage');
+    const leagueGroup = document.getElementById('eventLeagueFieldGroup');
+
+    // Show modal
+    setElementDisplay(modal, 'block');
+    document.body.style.overflow = 'hidden';
+
+    // Reset form and state
+    form.reset();
+    setElementDisplay(customLocationGroup, 'none');
+    setElementDisplay(formMessage, 'none');
+    setElementDisplay(leagueGroup, 'none');
+    clearSelectedGames('create');
+
+    // Character Counter
+    attachCharacterCounter('eventDescription', 250);
+
+    // Load games after modal is rendered
+    setTimeout(() => {
+        const dropdown = document.getElementById('gameDropdown');
+        if (dropdown) {
+            enableDropdown(dropdown);
+        }
+        initializeGameTagSelector('create');
+    }, 50);
+}
+
+// Close create event modal
+function closeCreateEventModal() {
+    const modal = document.getElementById('createEventModal');
+    setElementDisplay(modal, 'none');
+    document.body.style.overflow = 'auto';
+}
+
+// Handle location dropdown change
+function handleLocationChange(e) {
+    const customLocationGroup = document.getElementById('customLocationGroup');
+    const customLocationInput = document.getElementById('customLocation');
+
+    if (e.target.value === 'other') {
+        setElementDisplay(customLocationGroup, 'block');
+        customLocationInput.required = true;
+    } else {
+        setElementDisplay(customLocationGroup, 'none');
+        customLocationInput.required = false;
+        customLocationInput.value = '';
+    }
+}
+
+// Handle event type change - hide game field for Misc events
+function handleEventTypeChange() {
+    const eventType = document.getElementById('eventType')?.value;
+    const gameFieldGroup = document.getElementById('gameFieldGroup');
+
+    // Handle game field visibility for Misc events
+    if (eventType === 'Misc') {
+        setElementDisplay(gameFieldGroup, 'none');
+        clearSelectedGames('create');
+    } else {
+        setElementDisplay(gameFieldGroup, 'block');
+    }
+}
+
+// Toggle all-day event button
+function toggleAllDayEvent() {
+    const allDayCheckbox = document.getElementById('allDayEvent');
+    const allDayButton = document.getElementById('allDayButton');
+    const startTimeInput = document.getElementById('startTime');
+    const endTimeInput = document.getElementById('endTime');
+
+    if (!allDayCheckbox || !allDayButton || !startTimeInput || !endTimeInput) return;
+
+    // Toggle checkbox state
+    allDayCheckbox.checked = !allDayCheckbox.checked;
+
+    if (allDayCheckbox.checked) {
+        // Activate all-day mode
+        allDayButton.textContent = 'ALL DAY';
+        allDayButton.classList.add('active');
+
+        // Set all-day times
+        startTimeInput.value = '00:00';
+        endTimeInput.value = '23:59';
+
+        // Make inputs read-only
+        startTimeInput.readOnly = true;
+        endTimeInput.readOnly = true;
+        startTimeInput.style.opacity = '0.5';
+        endTimeInput.style.opacity = '0.5';
+
+        // Remove required attribute
+        startTimeInput.removeAttribute('required');
+        endTimeInput.removeAttribute('required');
+    } else {
+        // Deactivate all-day mode
+        allDayButton.textContent = 'ALL DAY?';
+        allDayButton.classList.remove('active');
+
+        // Clear times
+        startTimeInput.value = '';
+        endTimeInput.value = '';
+
+        // Enable inputs
+        startTimeInput.readOnly = false;
+        endTimeInput.readOnly = false;
+        startTimeInput.style.opacity = '1';
+        endTimeInput.style.opacity = '1';
+
+        // Add required attribute back
+        startTimeInput.setAttribute('required', 'required');
+        endTimeInput.setAttribute('required', 'required');
+    }
+}
+
+// Handle create event form submission
+async function handleCreateEventSubmit(e) {
+    e.preventDefault();
+
+    const submitBtn = e.target.querySelector('button[type="submit"]');
+    const submitBtnText = document.getElementById('submitBtnText');
+    const submitBtnSpinner = document.getElementById('submitBtnSpinner');
+    const formMessage = document.getElementById('formMessage');
+
+    // Validate league for Match events
+    const eventType = document.getElementById('eventType')?.value;
+    const leagueDropdown = document.getElementById('eventLeagueDropdown');
+
+    if (eventType === 'Match' && (!leagueDropdown?.value)) {
+        formMessage.textContent = 'Please select a league for Match events.';
+        formMessage.className = 'form-message error';
+        formMessage.style.display = 'block';
+        return;
+    }
+
+    // Set loading state
+    submitBtn.disabled = true;
+    setElementDisplay(submitBtnText, 'none');
+    setElementDisplay(submitBtnSpinner, 'inline-block');
+
+    const formData = new FormData(e.target);
+
+    // Handle custom location
+    const location = formData.get('eventLocation');
+    if (location === 'other') {
+        formData.set('eventLocation', formData.get('customLocation'));
+    }
+    formData.delete('customLocation');
+
+    try {
+        const response = await fetch('/event-register', {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            body: formData
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.success) {
+            // Direct manipulation
+            formMessage.innerHTML = (data.message || 'Event created successfully! Refreshing calendar...').replace(/\n/g, '<br>');
+            formMessage.className = 'form-message success';
+            formMessage.style.display = 'block';
+
+            setTimeout(() => window.location.reload(), 350);
+        } else {
+            throw new Error(data.message || 'Failed to create event');
+        }
+    } catch (error) {
+        // Direct manipulation for error
+        formMessage.textContent = error.message || 'Failed to create event. Please try again.';
+        formMessage.className = 'form-message error';
+        formMessage.style.display = 'block';
+
+        // Reset button state
+        submitBtn.disabled = false;
+        setElementDisplay(submitBtnText, 'inline');
+        setElementDisplay(submitBtnSpinner, 'none');
+    }
+}
+
+/* ==========================================
+   Edit Event
+   ========================================== */
+
+// Enables and disables event detail panel editing
+function togglePanelEditMode() {
+    const event = EventState.currentEventData;
+    if (!event) return;
+
+    // Replace title with input
+    const title = document.querySelector('.events-detail-panel .events-detail-title');
+    if (title) {
+        title.outerHTML = `<input id="panelEditName" class="events-detail-title panel-edit-input"
+                                  value="${escapeQuotes(event.name || '')}" type="text">`;
+    }
+
+    // Inject missing rows in correct order before transforming
+    const sections = document.querySelector('.events-detail-panel .events-detail-sections');
+    const existingLabels = [...sections.querySelectorAll('h4')].map(h => h.textContent.trim());
+
+    // Full ordered field list — Date is always present, skip Game for scheduled events
+    const allRows = [
+        { label: 'Time',        icon: 'clock'          },
+        ...(!event.is_scheduled ? [{ label: 'Game', icon: 'gamepad' }] : []),
+        { label: 'Location',    icon: 'map-marker-alt' },
+        { label: 'Description', icon: 'info-circle'    },
+    ];
+
+    // Insert missing rows in order relative to existing ones
+    allRows.forEach(({ label, icon }) => {
+        if (existingLabels.includes(label)) return;
+
+        // Find the row that should come after this one, insert before it
+        const allLabels = ['Date', 'Time', 'Game', 'Location', 'Description'];
+        const afterIndex = allLabels.indexOf(label);
+        let inserted = false;
+
+        for (let i = afterIndex + 1; i < allLabels.length; i++) {
+            const nextLabel = allLabels[i];
+            const nextRow = [...sections.querySelectorAll('.events-detail-row')]
+                .find(r => r.querySelector('h4')?.textContent.trim() === nextLabel);
+            if (nextRow) {
+                nextRow.insertAdjacentHTML('beforebegin', `
+                    <div class="events-detail-row">
+                        <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
+                        <div class="events-detail-row-text"><h4>${label}</h4><p></p></div>
+                    </div>
+                `);
+                inserted = true;
+                break;
+            }
+        }
+
+        // If no later row exists, append at end
+        if (!inserted) {
+            sections.insertAdjacentHTML('beforeend', `
+                <div class="events-detail-row">
+                    <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
+                    <div class="events-detail-row-text"><h4>${label}</h4><p></p></div>
+                </div>
+            `);
+        }
+    });
+
+    // Transform all rows to editable inputs
+    document.querySelectorAll('.events-detail-panel .events-detail-row').forEach(row => {
+        const label = row.querySelector('h4')?.textContent?.trim();
+        const valueEl = row.querySelector('p');
+        if (!valueEl) return;
+
+        switch (label) {
+            case 'Date':
+                valueEl.outerHTML = `<input id="panelEditDate" class="panel-edit-input"
+                                            type="date" value="${event.date_raw || ''}">`;
+                break;
+            case 'Time':
+                valueEl.outerHTML = `<div class="panel-edit-time-row">
+                    <input id="panelEditStartTime" class="panel-edit-input"
+                           type="time" value="${event.start_time_raw}">
+                    <span>–</span>
+                    <input id="panelEditEndTime" class="panel-edit-input"
+                           type="time" value="${event.end_time_raw}">
+                </div>`;
+                break;
+            case 'Game':
+                if (event.is_scheduled) break;
+                valueEl.outerHTML = `
+                    <div>
+                        <div id="editSelectedGamesContainer" class="selected-games-container"></div>
+                        <select id="editGameDropdown" class="panel-edit-input">
+                            <option value="">+ Add a game</option>
+                        </select>
+                        <div id="editGameLoadingIndicator" style="display:none; font-size:0.8125rem; color:var(--text-secondary); margin-top:0.5rem;">
+                            <i class="fas fa-spinner fa-spin"></i> Loading games...
+                        </div>
+                        <input type="hidden" id="editSelectedGamesInput" name="games" value="[]">
+                    </div>
+                `;
+                break;
+            case 'Location':
+                valueEl.outerHTML = `<select id="panelEditLocation" class="panel-edit-input">
+                    <option value="Campus Center" ${event.location === 'Campus Center' ? 'selected' : ''}>Campus Center</option>
+                    <option value="Campus Center Coffee House" ${event.location === 'Campus Center Coffee House' ? 'selected' : ''}>Campus Center Coffee House</option>
+                    <option value="Campus Center Event Room" ${event.location === 'Campus Center Event Room' ? 'selected' : ''}>Campus Center Event Room</option>
+                    <option value="D-108" ${event.location === 'D-108' ? 'selected' : ''}>D-108</option>
+                    <option value="Esports Lab (Commons Building 80)" ${event.location === 'Esports Lab (Commons Building 80)' ? 'selected' : ''}>Esports Lab</option>
+                    <option value="Lakeside Lodge" ${event.location === 'Lakeside Lodge' ? 'selected' : ''}>Lakeside Lodge</option>
+                    <option value="Online" ${event.location === 'Online' ? 'selected' : ''}>Online</option>
+                </select>`;
+                break;
+            case 'Description':
+                valueEl.outerHTML = `<textarea id="panelEditDescription" class="panel-edit-input"
+                                               rows="3">${event.description || ''}</textarea>`;
+                break;
+        }
+    });
+
+    // Initialize game editable field if not scheduled event
+    if (!event.is_scheduled) {
+        initializeGameTagSelector('edit', event.game);
+    }
+
+    //Attach description character counter
+    attachCharacterCounter('panelEditDescription', 250);
+
+    // Swap edit button for save/cancel
+    const editBtn = document.querySelector('.events-detail-banner-btn:not(.delete)');
+    if (editBtn) {
+        editBtn.outerHTML = `
+            <button class="events-detail-banner-btn panel-save-btn" onclick="submitPanelEdit()" title="Save changes">
+                <i class="fas fa-check"></i>
+            </button>
+            <button class="events-detail-banner-btn panel-cancel-btn" onclick="cancelPanelEdit()" title="Cancel">
+                <i class="fas fa-times"></i>
+            </button>
+        `;
+    }
+}
+
+// Cancel editing in the event detail panel
+function cancelPanelEdit() {
+    if (EventState.currentEventId) {
+        openEventDetailPanel(EventState.currentEventId);
+    }
+}
+
+// Confirms edits made in the event detail panel
+async function submitPanelEdit() {
+    const nameInput = document.getElementById('panelEditName');
+    if (!nameInput?.value?.trim()) {
+        nameInput?.classList.add('panel-edit-input-error');
+        nameInput?.focus();
+        return;
+    }
+    nameInput.classList.remove('panel-edit-input-error');
+
+    const saveBtn = document.querySelector('.panel-save-btn');
+    if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+
+    const locationSelect = document.getElementById('panelEditLocation');
+
+    const formData = {
+        event_id: EventState.currentEventId,
+        event_name: document.getElementById('panelEditName')?.value,
+        event_type: EventState.currentEventData?.event_type,
+        games: document.getElementById('editSelectedGamesInput')?.value ||
+                JSON.stringify(EventState.currentEventData?.game ? [EventState.currentEventData.game] : []),
+        event_date: document.getElementById('panelEditDate')?.value,
+        start_time: document.getElementById('panelEditStartTime')?.value,
+        end_time: document.getElementById('panelEditEndTime')?.value,
+        location: locationSelect?.value,
+        description: document.getElementById('panelEditDescription')?.value,
+        league_id: EventState.currentEventData?.league_id || null
+    };
+
+    try {
+        const response = await fetch('/api/event/edit', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(formData)
+        });
+        const data = await response.json();
+
+        if (data.success) {
+            // Refresh the panel and card with updated data
+            await openEventDetailPanel(EventState.currentEventId);
+            loadEvents();
+        } else {
+            throw new Error(data.message || 'Failed to update event');
+        }
+    } catch (error) {
+        console.error('Error saving event:', error);
+        if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-check"></i>';
+        alert(error.message || 'Failed to save changes.');
+    }
+}
+
+/* ==================================
+   Delete Event
+   ================================== */
+async function openDeleteEventModal(eventId, eventName) {
+    EventState.currentDeleteEventId = eventId;
+    EventState.currentDeleteEventName = eventName;
+
+    // Fetch event data if needed
+    if (!EventState.currentEventData || EventState.currentEventData.id !== eventId) {
+        try {
+            const response = await fetch(`/api/event/${eventId}`);
+            if (!response.ok) throw new Error('Failed to fetch event details');
+            EventState.currentEventData = await response.json();
+        } catch (error) {
+            console.error('Error fetching event data for deletion:', error);
+        }
+    }
+
+    const eventData = EventState.currentEventData;
+    const { is_developer } = EventState.permissions;
+    const timeRemaining = eventData ? getDeletionTimeRemaining(eventData.created_at) : null;
+
+    // Build additional info for time window
+    let additionalInfo = '';
+    if (!is_developer && timeRemaining) {
+        additionalInfo = `
+            <div style="margin-top: 1rem; padding: 0.75rem; background: rgba(251, 191, 36, 0.1);
+                        border: 1px solid #fbbf24; border-radius: 6px; font-size: 0.875rem;">
+                <i class="fas fa-clock" style="color: #fbbf24;"></i>
+                <strong style="color: #fbbf24;">Deletion window:</strong> ${timeRemaining}
+            </div>
+        `;
+    }
+
+    // Open universal modal with event-specific config
+    window.openDeleteConfirmModal({
+        title: 'Delete Event?',
+        itemName: eventName,
+        message: `Are you sure you want to delete ${eventName}? This action cannot be undone.`,
+        additionalInfo: additionalInfo,
+        buttonText: 'Delete Event',
+        onConfirm: confirmDeleteEvent,
+        itemId: eventId
+    });
+}
+
+// Function triggered when an event is confirmed to be deleted
+async function confirmDeleteEvent(eventId) {
+    try {
+        const response = await fetch(`/api/events/${eventId}`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' }
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+            window.closeDeleteConfirmModal();
+
+            // If deletion was from event modal, close that too
+            if (EventState.deletionFromModal) {
+                const eventModal = document.getElementById('eventDetailsModal');
+                if (eventModal) {
+                    eventModal.style.display = 'none';
+                }
+                EventState.deletionFromModal = false;
+            }
+
+            // Show success notification FIRST
+            showDeleteSuccessMessage(data.message);
+
+            // If schedule was auto-deleted, show additional notification with proper delay
+            if (data.schedule_deleted && data.schedule_name) {
+                // Wait for first notification to appear and settle
+                setTimeout(() => {
+                    if (typeof window.showInfoMessage === 'function') {
+                        window.showInfoMessage(
+                            `Schedule "${data.schedule_name}" was automatically removed (no events remaining)`,
+                            4000
+                        );
+                    } else if (typeof window.showScheduleCleanupNotification === 'function') {
+                        window.showScheduleCleanupNotification(data.schedule_name);
+                    }
+                }, 600); // Increased delay to ensure proper stacking
+            }
+
+            // Route based on deletion source
+            setTimeout(() => {
+                if (EventState.deletionSource === 'events') {
+                    // Reload events tab only
+                    loadEvents();
+                    // Manually restore scrolling
+                    document.body.style.overflow = 'auto';
+                } else {
+                    // Calendar view - ALWAYS full page reload
+                    window.location.reload();
+                }
+            }, data.schedule_deleted ? 2000 : 1000); // Longer delay if showing two notifications
+        } else {
+            handleDeleteError(data.message);
+        }
+    } catch (error) {
+        console.error('Error deleting event:', error);
+        showDeleteErrorMessage('An error occurred while deleting the event');
+        window.closeDeleteConfirmModal();
+    }
+}
+
+// Handle delete error messages
+function handleDeleteError(message) {
+    window.closeDeleteConfirmModal();
+
+    if (message.includes('expired') || message.includes('24')) {
+        showDeleteErrorMessage(`⏰ ${message}\n\nOnly developers can delete events after 24 hours.`);
+    } else if (message.includes('creator')) {
+        showDeleteErrorMessage(`🚫 ${message}`);
+    } else {
+        showDeleteErrorMessage('Error: ' + message);
+    }
+}
+
+// Delete event (called from event details modal)
+async function deleteEvent() {
+    if (!EventState.currentEventId) {
+        alert("Event ID not found.");
+        return;
+    }
+
+    const event = EventState.currentEventData;
+    if (!event) {
+        alert("Event data not found.");
+        return;
+    }
+
+    // Check if user can delete
+    if (!canUserDeleteEvent(event)) {
+        const { is_developer } = EventState.permissions;
+
+        if (!is_developer && event.created_by === (window.currentUserId || 0)) {
+            alert(" The 24-hour deletion window has expired.\n\nOnly developers can delete events after 24 hours.");
+        } else {
+            alert(" You don't have permission to delete this event.");
+        }
+        return;
+    }
+
+    // Track that deletion was initiated from modal
+    EventState.deletionFromModal = true;
+
+    // DON'T close the event modal - just open delete confirmation on top
+    openDeleteEventModal(event.id, event.name);
+}
+
+/* ================================
+   Event Detail Panel Display
+   ================================ */
+async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetchedBannerData = null) {
+    const pane = document.getElementById('eventsDetailPane');
+    if (window.innerWidth <= 768) {
+        pane.classList.add('sheet-open');
+        document.getElementById('sheetBackdrop')?.classList.add('open');
+        document.body.style.overflow = 'hidden';
+    }
+    EventState.currentEventId = eventId;
+
+    // Show loading state
+    pane.innerHTML = `
+        <div class="events-detail-placeholder">
+            <i class="fas fa-spinner fa-spin"></i>
+            <p>Loading event...</p>
+        </div>
+    `;
+
+    try {
+        const response = prefetchedEventData
+            ? { ok: true, json: () => prefetchedEventData }
+            : await fetch(`/api/event/${eventId}`);
+        if (!response.ok) throw new Error('Failed to fetch event');
+        const event = await response.json();
+        EventState.currentEventData = event;
+
+        const eventTypeClass = (event.event_type || 'event').toLowerCase();
+
+        // Build detail rows
+        const rows = [];
+
+        if (event.start_time) {
+            const timeStr = `${event.start_time}${event.end_time ? ' – ' + event.end_time : ''}`;
+            rows.push(detailRow('clock', 'Time', timeStr));
+        }
+
+        if (event.game && event.game !== 'N/A') {
+            rows.push(detailRow('gamepad', 'Game', event.game));
+        }
+
+        if (event.event_type === 'Match' && event.league_name) {
+            rows.push(detailRow('trophy', 'League', event.league_name));
+        }
+
+        if (event.location) {
+            rows.push(detailRow('map-marker-alt', 'Location', event.location));
+        }
+
+        if (event.description) {
+            rows.push(detailRow('info-circle', 'Description', event.description));
+        }
+
+        // Fetch banner and event data concurrently
+        const [bannerData] = await Promise.all([
+            prefetchedBannerData ||
+                fetch(`/api/event/${eventId}/games`).then(r => r.json()).catch(() => ({ success: false, games: [] }))
+        ]);
+
+        const banners = bannerData.success
+            ? (bannerData.games || []).filter(g => g.GameBanner).map(g => g.GameBanner)
+            : [];
+
+        const bannerHTML = banners.length
+            ? banners.map((url, i) => `
+                <img src="${url}" class="event-detail-banner-img event-detail-banner-slide ${i === 0 ? 'active' : ''}"
+                     alt="Game banner ${i + 1}">
+              `).join('')
+            : '';
+
+        pane.innerHTML = `
+            <div class="events-detail-panel" data-event-type="${eventTypeClass}">
+                <div class="events-detail-banner-wrapper">
+                    <div class="events-detail-banner" id="eventDetailBanner" ${!banners.length ? 'style="display:none"' : ''}>
+                        ${bannerHTML}
+                    </div>
+                    <div class="events-detail-banner-actions">
+                        ${canUserEditEvent(event) ? `
+                            <button class="events-detail-banner-btn" title="Edit event"
+                                    onclick="togglePanelEditMode()">
+                                <i class="fas fa-edit"></i>
+                            </button>` : ''}
+                        ${canUserDeleteEvent(event) ? `
+                            <button class="events-detail-banner-btn delete" title="Delete event"
+                                    onclick="openDeleteEventModal(${event.id}, '${escapeQuotes(event.name)}')">
+                                <i class="fas fa-trash"></i>
+                            </button>` : ''}
+                    </div>
+                </div>
+                <h2 class="events-detail-title">${event.name}</h2>
+                <div class="events-detail-sections">
+                    <div class="events-detail-row">
+                        <div class="event-detail-icon"><i class="fas fa-calendar-alt"></i></div>
+                        <div class="events-detail-row-text">
+                            <h4>Date</h4>
+                            <p>${event.date}</p>
+                        </div>
+                        <span class="game-next-event-type ${eventTypeClass} events-detail-type-badge">${event.event_type || 'Event'}</span>
+                    </div>
+                    ${rows.join('')}
+                </div>
+                <div class="notification-opt-in">
+                    <div class="notification-icon"><i class="fas fa-bell"></i></div>
+                    <div class="notification-text">
+                        <div class="title">Event Reminders</div>
+                        <div class="subtitle">Get notified about this event</div>
+                    </div>
+                    <button class="notification-btn" id="detailSubscribeBtn"
+                            onclick="toggleEventSubscription()">
+                        <span id="detailSubscribeBtnText">Loading...</span>
+                    </button>
+                </div>
+            </div>
+        `;
+
+        // Re-apply scroll lock on mobile after innerHTML replacement
+        if (window.innerWidth <= 768) {
+            document.body.style.overflow = 'hidden';
+        }
+
+        // Now load the notification section
+        await loadNotificationSection(eventId);
+
+        // Start slideshow if multiple banners
+        if (banners.length > 1) {
+            startBannerSlideshow(document.getElementById('eventDetailBanner'))
+        }
+
+    } catch (error) {
+        console.error('Error loading event detail panel:', error);
+        pane.innerHTML = `
+            <div class="events-detail-placeholder">
+                <i class="fas fa-exclamation-circle"></i>
+                <p>Failed to load event details.</p>
+            </div>
+        `;
+    }
+}
+
+// Build a single detail row for the panel
+function detailRow(icon, label, value) {
+    return `
+        <div class="events-detail-row">
+            <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
+            <div class="events-detail-row-text">
+                <h4>${label}</h4>
+                <p>${value}</p>
+            </div>
+        </div>
+    `;
+}
+
+// Closes the event detail pane in MOBILE VIEW
+function closeEventDetailSheet() {
+    const pane = document.getElementById('eventsDetailPane');
+    pane?.classList.remove('sheet-open');
+    document.getElementById('sheetBackdrop')?.classList.remove('open');
+    document.body.style.overflow = '';
+}
+
+/* =======================================
+   Build Filter System
+   ======================================= */
 
 // Build different filter options for events
 function buildEventFilterParams() {
@@ -243,6 +1110,355 @@ async function loadGamesList() {
     }
 }
 
+// Populate single-select game dropdown for filter
+async function populateGameDropdown(selectId, loadingIndicatorId = null, selectedGame = null) {
+    const selectElement = document.getElementById(selectId);
+    if (!selectElement) return;
+
+    const loadingIndicator = loadingIndicatorId ? document.getElementById(loadingIndicatorId) : null;
+
+    // Show loading
+    setElementDisplay(loadingIndicator, 'block');
+    selectElement.disabled = true;
+
+    try {
+        const games = await loadGamesList();
+
+        // Clear and populate
+        selectElement.innerHTML = '<option value="">Select game</option>';
+
+        if (games.length === 0) {
+            selectElement.innerHTML += '<option value="" disabled>No games available</option>';
+            return;
+        }
+
+        games.forEach(game => {
+            const option = document.createElement('option');
+            option.value = game.GameTitle;
+            option.textContent = game.GameTitle;
+            option.selected = (selectedGame && game.GameTitle === selectedGame);
+            selectElement.appendChild(option);
+        });
+
+    } catch (error) {
+        console.error('Error populating game dropdown:', error);
+        selectElement.innerHTML = '<option value="">Error loading games</option>';
+    } finally {
+        setElementDisplay(loadingIndicator, 'none');
+        selectElement.disabled = false;
+    }
+}
+
+// Load games for filter dropdown
+async function loadGamesForFilter() {
+    await populateGameDropdown('gameFilter', 'gameFilterLoadingIndicator');
+}
+
+/* =================================
+   Filter UI
+   ================================= */
+function toggleFilterBox(panelId) {
+    const panel = document.getElementById(panelId);
+    const btn = panel?.previousElementSibling;
+    const isOpen = panel?.classList.contains('open');
+
+    document.querySelectorAll('.filter-box-panel.open').forEach(p => {
+        p.classList.remove('open');
+        p.previousElementSibling?.classList.remove('active');
+    });
+
+    const filterBackdrop = document.getElementById('filterBackdrop');
+
+    if (!isOpen) {
+        panel?.classList.add('open');
+        btn?.classList.add('active');
+        if (window.innerWidth <= 768 && filterBackdrop) {
+            filterBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+    } else {
+        filterBackdrop?.classList.remove('open');
+        document.body.style.overflow = '';
+    }
+}
+
+function applyPrimaryFilter(value, label) {
+    document.getElementById('filterBox1Label').textContent = label;
+    document.getElementById('eventFilter').value = value;
+    EventState.selectedGame = null;
+    closeAllFilterPanels();
+
+    // Hide Box 2 and reset season state
+    document.getElementById('filterBox2').style.display = 'none';
+    PastSeasonFilterState.selectedSeasonId = null;
+    PastSeasonFilterState.isFilteringPastSeason = false;
+
+    filterEvents();
+}
+
+function applyPrimaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
+    document.getElementById('filterBox1Label').textContent = `${filterLabel}: ${subLabel}`;
+    document.getElementById('eventFilter').value = filterVal;
+    document.getElementById(subSelectId).value = subVal;
+    if (filterVal === 'game') EventState.selectedGame = subVal;
+    closeAllFilterPanels();
+
+    document.getElementById('filterBox2').style.display = 'none';
+    PastSeasonFilterState.selectedSeasonId = null;
+    PastSeasonFilterState.isFilteringPastSeason = false;
+
+    if (filterVal === 'game') {
+        filterEventsByGame();
+    } else {
+        handleTypeFilterChange();
+    }
+}
+
+function applyPastSeasonFilter(seasonId, seasonName) {
+    document.getElementById('filterBox1Label').textContent = seasonName;
+    document.getElementById('eventFilter').value = 'past_season';
+    document.getElementById('pastSeasonSelect').value = seasonId;
+    closeAllFilterPanels();
+
+    PastSeasonFilterState.isFilteringPastSeason = true;
+    PastSeasonFilterState.selectedSeasonId = seasonId;
+    PastSeasonFilterState.selectedSeasonName = seasonName;
+    PastSeasonFilterState.secondaryFilter = 'all';
+
+    // Show Box 2 with reset label
+    document.getElementById('filterBox2Label').textContent = 'All Events';
+    document.getElementById('filterBox2').style.display = 'block';
+
+    loadEventsForPastSeason();
+}
+
+function applySecondaryFilter(value, label) {
+    document.getElementById('filterBox2Label').textContent = label;
+    document.getElementById('pastSeasonSecondaryFilter').value = value;
+    closeAllFilterPanels();
+    PastSeasonFilterState.secondaryFilter = value;
+    PastSeasonFilterState.selectedGame = null;
+    loadEventsForPastSeason();
+}
+
+function applySecondaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
+    document.getElementById('filterBox2Label').textContent = `${filterLabel}: ${subLabel}`;
+    document.getElementById('pastSeasonSecondaryFilter').value = filterVal;
+    document.getElementById(subSelectId).value = subVal;
+    PastSeasonFilterState.secondaryFilter = filterVal;
+    if (filterVal === 'game') PastSeasonFilterState.selectedGame = subVal;
+    closeAllFilterPanels();
+    loadEventsForPastSeason();
+}
+
+function closeAllFilterPanels() {
+    document.querySelectorAll('.filter-box-panel.open').forEach(p => {
+        p.classList.remove('open');
+        p.previousElementSibling?.classList.remove('active');
+    });
+    document.getElementById('filterBackdrop')?.classList.remove('open');
+    document.body.style.overflow = '';
+}
+
+// Populate past seasons flyout on hover
+function initPastSeasonsFlyout() {
+    const trigger = document.getElementById('pastSeasonsFlyoutTrigger');
+    const flyout = document.getElementById('pastSeasonsFlyout');
+    if (!trigger || !flyout) return;
+
+    let loaded = false;
+    trigger.addEventListener('mouseenter', async () => {
+        if (loaded) return;
+        loaded = true;
+        try {
+            const response = await fetch('/api/seasons/past');
+            const data = await response.json();
+            if (data.success && data.seasons?.length) {
+                flyout.innerHTML = data.seasons.map(s => `
+                    <div class="filter-box-flyout-item"
+                         onclick="applyPastSeasonFilter('${s.season_id}', '${s.season_name.replace(/'/g, "\\'")}')">
+                        ${s.season_name}
+                    </div>
+                `).join('');
+            } else {
+                flyout.innerHTML = '<div class="filter-box-flyout-loading">No past seasons</div>';
+            }
+        } catch {
+            flyout.innerHTML = '<div class="filter-box-flyout-loading">Failed to load</div>';
+        }
+    });
+}
+
+// Populate game flyouts on hover (both Box 1 and Box 2)
+function initGameFlyouts() {
+    ['gameFilterFlyoutTrigger1', 'gameFilterFlyoutTrigger2'].forEach((triggerId, i) => {
+        const trigger = document.getElementById(triggerId);
+        const flyout = document.getElementById(`gameFilterFlyout${i + 1}`);
+        if (!trigger || !flyout) return;
+
+        let loaded = false;
+        trigger.addEventListener('mouseenter', async () => {
+            if (loaded) return;
+            loaded = true;
+            try {
+                const games = await loadGamesList();
+                if (games?.length) {
+                    flyout.innerHTML = games.map(g => `
+                        <div class="filter-box-flyout-item"
+                             onclick="${i === 0
+                                ? `applyPrimaryFilterWithSub('game','Game','gameFilter','${g.GameTitle.replace(/'/g, "\\'")}','${g.GameTitle.replace(/'/g, "\\'")}')` : `applySecondaryFilterWithSub('game','Game','gameFilter','${g.GameTitle.replace(/'/g, "\\'")}','${g.GameTitle.replace(/'/g, "\\'")}')`
+                             }">
+                            ${g.GameTitle}
+                        </div>
+                    `).join('');
+                } else {
+                    flyout.innerHTML = '<div class="filter-box-flyout-loading">No games found</div>';
+                }
+            } catch {
+                flyout.innerHTML = '<div class="filter-box-flyout-loading">Failed to load</div>';
+            }
+        });
+    });
+}
+
+// Close panels when clicking outside for MOBILE VIEW
+document.addEventListener('click', (e) => {
+    if (!e.target.closest('.filter-box')) {
+        closeAllFilterPanels();
+    }
+});
+
+/* ===============================
+   Event Filtering
+   =============================== */
+// Filter events based on dropdown selection
+function filterEvents() {
+    const filterSelect = document.getElementById('eventFilter');
+    const filterValue = filterSelect?.value || 'all';
+
+    const typeFilterContainer = document.getElementById('eventTypeFilterContainer');
+    const typeFilterSelect = document.getElementById('eventTypeFilter');
+    const gameFilterContainer = document.getElementById('gameFilterContainer');
+    const gameFilterSelect = document.getElementById('gameFilter');
+
+    // Past season-specific elements
+    const pastSeasonSelectContainer = document.getElementById('pastSeasonSelectContainer');
+    const pastSeasonSecondaryFilterContainer = document.getElementById('pastSeasonSecondaryFilterContainer');
+
+    // Hide all secondary filters by default
+    setElementDisplay(typeFilterContainer, 'none');
+    setElementDisplay(gameFilterContainer, 'none');
+    setElementDisplay(pastSeasonSelectContainer, 'none');
+    setElementDisplay(pastSeasonSecondaryFilterContainer, 'none');
+
+    // Reset secondary filters
+    if (typeFilterSelect) typeFilterSelect.value = '';
+    if (gameFilterSelect) gameFilterSelect.value = '';
+
+    // Reset past season filter state
+    PastSeasonFilterState.selectedSeasonId = null;
+    PastSeasonFilterState.selectedSeasonName = '';
+    PastSeasonFilterState.secondaryFilter = 'all';
+    PastSeasonFilterState.isFilteringPastSeason = false;
+
+    // Handle past season filter
+    if (filterValue === 'past_season') {
+        PastSeasonFilterState.isFilteringPastSeason = true;
+        setElementDisplay(pastSeasonSelectContainer, 'flex');
+        loadPastSeasonsForFilter();
+        return; // Don't load events yet, wait for season selection
+    }
+
+    // Show appropriate secondary filter for non-season filters
+    if (filterValue === 'type') {
+        setElementDisplay(typeFilterContainer, 'flex');
+        return;
+    } else if (filterValue === 'game') {
+        setElementDisplay(gameFilterContainer, 'flex');
+        loadGamesForFilter();
+        return;
+    }
+
+    // Load events with main filter (defaults to current active season on backend)
+    loadEvents();
+}
+
+// Handle type filter change
+function handleTypeFilterChange() {
+    if (PastSeasonFilterState.isFilteringPastSeason) {
+        if (document.getElementById('eventTypeFilter')?.value) loadEventsForPastSeason();
+    } else {
+        filterEventsByType();
+    }
+}
+
+// Handle game filter change
+function handleGameFilterChange() {
+    if (PastSeasonFilterState.isFilteringPastSeason) {
+        if (document.getElementById('gameFilter')?.value) loadEventsForPastSeason();
+    } else {
+        filterEventsByGame();
+    }
+}
+
+// Filter events by type (called when type dropdown changes)
+function filterEventsByType() {
+    const typeFilterSelect = document.getElementById('eventTypeFilter');
+    if (typeFilterSelect?.value) {
+        loadEvents();
+    }
+}
+
+// Filter events by game (called when game dropdown changes)
+function filterEventsByGame() {
+    const gameFilterSelect = document.getElementById('gameFilter');
+    if (gameFilterSelect?.value || EventState.selectedGame) {
+        loadEvents();
+    }
+}
+
+/* ================================
+    SEASON FILTERING
+   ================================ */
+
+// Global state for season filtering
+const PastSeasonFilterState = {
+    selectedSeasonId: null,
+    selectedSeasonName: '',
+    availablePastSeasons: [],
+    secondaryFilter: 'all',
+    isFilteringPastSeason: false,
+    selectedGame: null
+};
+
+// Filter events by past season and secondary filter
+function filterEventsByPastSeason() {
+    const secondaryFilter = document.getElementById('pastSeasonSecondaryFilter');
+    const secondaryValue = secondaryFilter?.value || 'all';
+
+    PastSeasonFilterState.secondaryFilter = secondaryValue;
+
+    const typeFilterContainer = document.getElementById('eventTypeFilterContainer');
+    const gameFilterContainer = document.getElementById('gameFilterContainer');
+
+    // Hide both tertiary filters
+    setElementDisplay(typeFilterContainer, 'none');
+    setElementDisplay(gameFilterContainer, 'none');
+
+    // Show appropriate tertiary filter
+    if (secondaryValue === 'type') {
+        setElementDisplay(typeFilterContainer, 'flex');
+        return; // Wait for type selection
+    } else if (secondaryValue === 'game') {
+        setElementDisplay(gameFilterContainer, 'flex');
+        loadGamesForFilter();
+        return; // Wait for game selection
+    }
+
+    // Load events with secondary filter
+    loadEventsForPastSeason();
+}
+
 /* ===============================
    Game Dropdown Tag System
    =============================== */
@@ -261,11 +1477,7 @@ const GameTagConfig = {
     }
 };
 
-/**
- * Initialize game tag selector for a specific context
- * @param {string} context - Either 'create' or 'edit'
- * @param {string} preSelectedGames - Comma-separated list of games to pre-select (for edit)
- */
+// Initialize game tag selector for a specific context
 async function initializeGameTagSelector(context = 'create', preSelectedGames = '') {
     const config = GameTagConfig[context];
     if (!config) {
@@ -432,655 +1644,30 @@ function clearSelectedGames(context = 'create') {
     updateDropdownOptions(context);
 }
 
-/* ===============================
-   Event Filtering
-   =============================== */
-
-// Global state for season filtering
-const PastSeasonFilterState = {
-    selectedSeasonId: null,
-    selectedSeasonName: '',
-    availablePastSeasons: [],
-    secondaryFilter: 'all',
-    isFilteringPastSeason: false
-};
-
-// Populate single-select game dropdown for filter
-async function populateGameDropdown(selectId, loadingIndicatorId = null, selectedGame = null) {
-    const selectElement = document.getElementById(selectId);
-    if (!selectElement) return;
-
-    const loadingIndicator = loadingIndicatorId ? document.getElementById(loadingIndicatorId) : null;
-
-    // Show loading
-    setElementDisplay(loadingIndicator, 'block');
-    selectElement.disabled = true;
-
-    try {
-        const games = await loadGamesList();
-
-        // Clear and populate
-        selectElement.innerHTML = '<option value="">Select game</option>';
-
-        if (games.length === 0) {
-            selectElement.innerHTML += '<option value="" disabled>No games available</option>';
-            return;
-        }
-
-        games.forEach(game => {
-            const option = document.createElement('option');
-            option.value = game.GameTitle;
-            option.textContent = game.GameTitle;
-            option.selected = (selectedGame && game.GameTitle === selectedGame);
-            selectElement.appendChild(option);
-        });
-
-    } catch (error) {
-        console.error('Error populating game dropdown:', error);
-        selectElement.innerHTML = '<option value="">Error loading games</option>';
-    } finally {
-        setElementDisplay(loadingIndicator, 'none');
-        selectElement.disabled = false;
-    }
-}
-
-// Load games for filter dropdown
-async function loadGamesForFilter() {
-    await populateGameDropdown('gameFilter', 'gameFilterLoadingIndicator');
-}
-
-// Load past seasons filter
-async function loadPastSeasonsForFilter() {
-    const seasonSelect = document.getElementById('pastSeasonSelect');
-    const loadingIndicator = document.getElementById('pastSeasonLoadingIndicator');
-
-    if (!seasonSelect) return;
-
-    // Show loading
-    setElementDisplay(loadingIndicator, 'inline-block');
-    seasonSelect.disabled = true;
-
-    try {
-        const response = await fetch('/api/seasons/past');
-        const data = await response.json();
-
-        if (data.success && data.seasons) {
-            PastSeasonFilterState.availablePastSeasons = data.seasons;
-
-            // Clear and populate dropdown
-            seasonSelect.innerHTML = '<option value="">Select Past Season</option>';
-
-            if (data.seasons.length === 0) {
-                seasonSelect.innerHTML += '<option value="" disabled>No past seasons available</option>';
-            } else {
-                data.seasons.forEach(season => {
-                    const option = document.createElement('option');
-                    option.value = season.season_id;
-                    option.textContent = season.season_name;
-                    seasonSelect.appendChild(option);
-                });
-            }
-        } else {
-            console.error('Failed to load past seasons:', data.message);
-            seasonSelect.innerHTML = '<option value="">Error loading past seasons</option>';
-        }
-    } catch (error) {
-        console.error('Error fetching past seasons:', error);
-        seasonSelect.innerHTML = '<option value="">Error loading past seasons</option>';
-    } finally {
-        setElementDisplay(loadingIndicator, 'none');
-        seasonSelect.disabled = false;
-    }
-}
-
-// Filter events based on dropdown selection
-function filterEvents() {
-    const filterSelect = document.getElementById('eventFilter');
-    const filterValue = filterSelect?.value || 'all';
-
-    const typeFilterContainer = document.getElementById('eventTypeFilterContainer');
-    const typeFilterSelect = document.getElementById('eventTypeFilter');
-    const gameFilterContainer = document.getElementById('gameFilterContainer');
-    const gameFilterSelect = document.getElementById('gameFilter');
-
-    // Past season-specific elements
-    const pastSeasonSelectContainer = document.getElementById('pastSeasonSelectContainer');
-    const pastSeasonSecondaryFilterContainer = document.getElementById('pastSeasonSecondaryFilterContainer');
-
-    // Hide all secondary filters by default
-    setElementDisplay(typeFilterContainer, 'none');
-    setElementDisplay(gameFilterContainer, 'none');
-    setElementDisplay(pastSeasonSelectContainer, 'none');
-    setElementDisplay(pastSeasonSecondaryFilterContainer, 'none');
-
-    // Reset secondary filters
-    if (typeFilterSelect) typeFilterSelect.value = '';
-    if (gameFilterSelect) gameFilterSelect.value = '';
-
-    // Reset past season filter state
-    PastSeasonFilterState.selectedSeasonId = null;
-    PastSeasonFilterState.selectedSeasonName = '';
-    PastSeasonFilterState.secondaryFilter = 'all';
-    PastSeasonFilterState.isFilteringPastSeason = false;
-
-    // Handle past season filter
-    if (filterValue === 'past_season') {
-        PastSeasonFilterState.isFilteringPastSeason = true;
-        setElementDisplay(pastSeasonSelectContainer, 'flex');
-        loadPastSeasonsForFilter();
-        return; // Don't load events yet, wait for season selection
-    }
-
-    // Show appropriate secondary filter for non-season filters
-    if (filterValue === 'type') {
-        setElementDisplay(typeFilterContainer, 'flex');
-        return;
-    } else if (filterValue === 'game') {
-        setElementDisplay(gameFilterContainer, 'flex');
-        loadGamesForFilter();
-        return;
-    }
-
-
-
-    // Load events with main filter (defaults to current active season on backend)
-    loadEvents();
-}
-
-/* ================================
-    SEASON FILTERING
-   ================================ */
-
-// Handle past season selection
-function handlePastSeasonSelection() {
-    const seasonSelect = document.getElementById('pastSeasonSelect');
-    const seasonId = seasonSelect?.value;
-    const seasonSecondaryFilterContainer = document.getElementById('pastSeasonSecondaryFilterContainer');
-
-    if (!seasonId) {
-        // No season selected, hide secondary filter
-        setElementDisplay(seasonSecondaryFilterContainer, 'none');
-        PastSeasonFilterState.selectedSeasonId = null;
-        PastSeasonFilterState.selectedSeasonName = '';
-        return;
-    }
-
-    // Store selected past season
-    PastSeasonFilterState.selectedSeasonId = seasonId;
-    PastSeasonFilterState.selectedSeasonName = seasonSelect.options[seasonSelect.selectedIndex].text;
-
-    // Show secondary filter
-    setElementDisplay(seasonSecondaryFilterContainer, 'flex');
-
-    // Reset secondary filter to "All Events"
-    const secondaryFilter = document.getElementById('pastSeasonSecondaryFilter');
-    if (secondaryFilter) {
-        secondaryFilter.value = 'all';
-    }
-
-    // Load events for this past season
-    loadEventsForPastSeason();
-
-
-}
-
-// Filter events by past season and secondary filter
-function filterEventsByPastSeason() {
-    const secondaryFilter = document.getElementById('pastSeasonSecondaryFilter');
-    const secondaryValue = secondaryFilter?.value || 'all';
-
-    PastSeasonFilterState.secondaryFilter = secondaryValue;
-
-    const typeFilterContainer = document.getElementById('eventTypeFilterContainer');
-    const gameFilterContainer = document.getElementById('gameFilterContainer');
-
-    // Hide both tertiary filters
-    setElementDisplay(typeFilterContainer, 'none');
-    setElementDisplay(gameFilterContainer, 'none');
-
-    // Show appropriate tertiary filter
-    if (secondaryValue === 'type') {
-        setElementDisplay(typeFilterContainer, 'flex');
-        return; // Wait for type selection
-    } else if (secondaryValue === 'game') {
-        setElementDisplay(gameFilterContainer, 'flex');
-        loadGamesForFilter();
-        return; // Wait for game selection
-    }
-
-    // Load events with secondary filter
-    loadEventsForPastSeason();
-
-
-}
-
-// Filter by past season and type
-function filterBySeasonAndType() {
-    const typeFilter = document.getElementById('eventTypeFilter');
-    if (typeFilter?.value) {
-        loadEventsForPastSeason();
-    }
-}
-
-// Filter by past season and game
-function filterBySeasonAndGame() {
-    const gameFilter = document.getElementById('gameFilter');
-    if (gameFilter?.value) {
-        loadEventsForPastSeason();
-    }
-}
-
-// Handle type filter change - routes to correct function based on context
-function handleTypeFilterChange() {
-    if (PastSeasonFilterState.isFilteringPastSeason) {
-        filterBySeasonAndType();
-    } else {
-        filterEventsByType();
-    }
-}
-
-// Handle game filter change - routes to correct function based on context
-function handleGameFilterChange() {
-    if (PastSeasonFilterState.isFilteringPastSeason) {
-        filterBySeasonAndGame();
-    } else {
-        filterEventsByGame();
-    }
-}
-
-// ============================================
-// FILTER BOX UI
-// ============================================
-function toggleFilterBox(panelId) {
-    const panel = document.getElementById(panelId);
-    const btn = panel?.previousElementSibling;
-    const isOpen = panel?.classList.contains('open');
-
-    document.querySelectorAll('.filter-box-panel.open').forEach(p => {
-        p.classList.remove('open');
-        p.previousElementSibling?.classList.remove('active');
-    });
-
-    const filterBackdrop = document.getElementById('filterBackdrop');
-
-    if (!isOpen) {
-        panel?.classList.add('open');
-        btn?.classList.add('active');
-        if (window.innerWidth <= 768 && filterBackdrop) {
-            filterBackdrop.classList.add('open');
-            document.body.style.overflow = 'hidden';
-        }
-    } else {
-        filterBackdrop?.classList.remove('open');
-        document.body.style.overflow = '';
-    }
-}
-
-function applyPrimaryFilter(value, label) {
-    document.getElementById('filterBox1Label').textContent = label;
-    document.getElementById('eventFilter').value = value;
-    EventState.selectedGame = null;
-    closeAllFilterPanels();
-
-    // Hide Box 2 and reset season state
-    document.getElementById('filterBox2').style.display = 'none';
-    PastSeasonFilterState.selectedSeasonId = null;
-    PastSeasonFilterState.isFilteringPastSeason = false;
-
-    filterEvents();
-}
-
-function applyPrimaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
-    document.getElementById('filterBox1Label').textContent = `${filterLabel}: ${subLabel}`;
-    document.getElementById('eventFilter').value = filterVal;
-    document.getElementById(subSelectId).value = subVal;
-    if (filterVal === 'game') EventState.selectedGame = subVal;
-    closeAllFilterPanels();
-
-    document.getElementById('filterBox2').style.display = 'none';
-    PastSeasonFilterState.selectedSeasonId = null;
-    PastSeasonFilterState.isFilteringPastSeason = false;
-
-    if (filterVal === 'game') {
-        filterEventsByGame();
-    } else {
-        handleTypeFilterChange();
-    }
-}
-
-function applyPastSeasonFilter(seasonId, seasonName) {
-    document.getElementById('filterBox1Label').textContent = seasonName;
-    document.getElementById('eventFilter').value = 'past_season';
-    document.getElementById('pastSeasonSelect').value = seasonId;
-    closeAllFilterPanels();
-
-    PastSeasonFilterState.isFilteringPastSeason = true;
-    PastSeasonFilterState.selectedSeasonId = seasonId;
-    PastSeasonFilterState.selectedSeasonName = seasonName;
-    PastSeasonFilterState.secondaryFilter = 'all';
-
-    // Show Box 2 with reset label
-    document.getElementById('filterBox2Label').textContent = 'All Events';
-    document.getElementById('filterBox2').style.display = 'block';
-
-    loadEventsForPastSeason();
-}
-
-function applySecondaryFilter(value, label) {
-    document.getElementById('filterBox2Label').textContent = label;
-    document.getElementById('pastSeasonSecondaryFilter').value = value;
-    closeAllFilterPanels();
-    PastSeasonFilterState.secondaryFilter = value;
-    loadEventsForPastSeason();
-}
-
-function applySecondaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
-    document.getElementById('filterBox2Label').textContent = `${filterLabel}: ${subLabel}`;
-    document.getElementById('pastSeasonSecondaryFilter').value = filterVal;
-    document.getElementById(subSelectId).value = subVal;
-    PastSeasonFilterState.secondaryFilter = filterVal;
-    closeAllFilterPanels();
-    loadEventsForPastSeason();
-}
-
-function closeAllFilterPanels() {
-    document.querySelectorAll('.filter-box-panel.open').forEach(p => {
-        p.classList.remove('open');
-        p.previousElementSibling?.classList.remove('active');
-    });
-    document.getElementById('filterBackdrop')?.classList.remove('open');
-    document.body.style.overflow = '';
-}
-
-// Populate past seasons flyout on hover
-function initPastSeasonsFlyout() {
-    const trigger = document.getElementById('pastSeasonsFlyoutTrigger');
-    const flyout = document.getElementById('pastSeasonsFlyout');
-    if (!trigger || !flyout) return;
-
-    let loaded = false;
-    trigger.addEventListener('mouseenter', async () => {
-        if (loaded) return;
-        loaded = true;
-        try {
-            const response = await fetch('/api/seasons/past');
-            const data = await response.json();
-            if (data.success && data.seasons?.length) {
-                flyout.innerHTML = data.seasons.map(s => `
-                    <div class="filter-box-flyout-item"
-                         onclick="applyPastSeasonFilter('${s.season_id}', '${s.season_name.replace(/'/g, "\\'")}')">
-                        ${s.season_name}
-                    </div>
-                `).join('');
-            } else {
-                flyout.innerHTML = '<div class="filter-box-flyout-loading">No past seasons</div>';
-            }
-        } catch {
-            flyout.innerHTML = '<div class="filter-box-flyout-loading">Failed to load</div>';
-        }
-    });
-}
-
-// Populate game flyouts on hover (both Box 1 and Box 2)
-function initGameFlyouts() {
-    ['gameFilterFlyoutTrigger1', 'gameFilterFlyoutTrigger2'].forEach((triggerId, i) => {
-        const trigger = document.getElementById(triggerId);
-        const flyout = document.getElementById(`gameFilterFlyout${i + 1}`);
-        if (!trigger || !flyout) return;
-
-        let loaded = false;
-        trigger.addEventListener('mouseenter', async () => {
-            if (loaded) return;
-            loaded = true;
-            try {
-                const games = await loadGamesList();
-                if (games?.length) {
-                    flyout.innerHTML = games.map(g => `
-                        <div class="filter-box-flyout-item"
-                             onclick="${i === 0
-                                ? `applyPrimaryFilterWithSub('game','Game','gameFilter','${g.GameTitle.replace(/'/g, "\\'")}','${g.GameTitle.replace(/'/g, "\\'")}')` : `applySecondaryFilterWithSub('game','Game','gameFilter','${g.GameTitle.replace(/'/g, "\\'")}','${g.GameTitle.replace(/'/g, "\\'")}')`
-                             }">
-                            ${g.GameTitle}
-                        </div>
-                    `).join('');
-                } else {
-                    flyout.innerHTML = '<div class="filter-box-flyout-loading">No games found</div>';
-                }
-            } catch {
-                flyout.innerHTML = '<div class="filter-box-flyout-loading">Failed to load</div>';
-            }
-        });
-    });
-}
-
-// Close panels when clicking outside
-document.addEventListener('click', (e) => {
-    if (!e.target.closest('.filter-box')) {
-        closeAllFilterPanels();
-    }
-});
-
-// Load events for selected past season with filters
-function loadEventsForPastSeason() {
-    if (!PastSeasonFilterState.selectedSeasonId) {
-        console.warn('No past season selected');
-        return;
-    }
-
-    const elements = {
-        loading: document.getElementById('eventsLoading'),
-        container: document.getElementById('eventsContainer'),
-        emptyState: document.getElementById('eventsEmptyState')
-    };
-
-    // Show loading state
-    setElementDisplay(elements.loading, 'block');
-    setElementDisplay(elements.container, 'none');
-    setElementDisplay(elements.emptyState, 'none');
-
-    // Build query parameters
-    let queryParams = `season_id=${PastSeasonFilterState.selectedSeasonId}`;
-
-    // Add secondary filter
-    const secondaryFilter = PastSeasonFilterState.secondaryFilter;
-
-    if (secondaryFilter === 'created_by_me') {
-        queryParams += '&filter=created_by_me';
-    } else if (secondaryFilter === 'type') {
-        const typeFilter = document.getElementById('eventTypeFilter')?.value;
-        if (typeFilter) {
-            queryParams += `&filter=type&event_type=${typeFilter}`;
-        }
-    } else if (secondaryFilter === 'game') {
-        const gameFilter = document.getElementById('gameFilter')?.value;
-        if (gameFilter) {
-            queryParams += `&filter=game&game=${encodeURIComponent(gameFilter)}`;
-        }
-    } else {
-        // "all" - just use season filter
-        queryParams += '&filter=all';
-    }
-
-    // Fetch events
-    fetch(`/api/events?${queryParams}`)
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                EventState.setPermissions(data.is_admin, data.is_developer, data.is_gm);
-                renderEvents(data.events, data.is_admin, data.is_developer, data.is_gm);
-
-                // Update empty state message for season filtering
-                updatePastSeasonEmptyStateMessage();
-            } else {
-                console.error('Failed to load events:', data.message);
-                showEventsError();
-            }
-        })
-        .catch(error => {
-            console.error('Error loading events:', error);
-            showEventsError();
-        })
-        .finally(() => {
-            setElementDisplay(elements.loading, 'none');
-        });
-}
-
-// Update empty state message for past season filtering
-function updatePastSeasonEmptyStateMessage() {
-    const emptyStateDiv = document.getElementById('eventsEmptyState');
-    const emptyStateTitle = emptyStateDiv?.querySelector('h3');
-    const emptyStateText = emptyStateDiv?.querySelector('p');
-
-    if (!emptyStateTitle || !emptyStateText) return;
-
-    const seasonName = PastSeasonFilterState.selectedSeasonName;
-    const secondaryFilter = PastSeasonFilterState.secondaryFilter;
-
-    let title = `No Events in ${seasonName}`;
-    let text = `No events found for ${seasonName}.`;
-
-    if (secondaryFilter === 'created_by_me') {
-        title = `No Events Created in ${seasonName}`;
-        text = `You haven't created any events in ${seasonName}.`;
-    } else if (secondaryFilter === 'type') {
-        const typeSelect = document.getElementById('eventTypeFilter');
-        const typeName = typeSelect?.options[typeSelect.selectedIndex]?.text || 'Selected';
-        title = `No ${typeName} Events in ${seasonName}`;
-        text = `No ${typeName.toLowerCase()} events found in ${seasonName}.`;
-    } else if (secondaryFilter === 'game') {
-        const gameSelect = document.getElementById('gameFilter');
-        const gameName = gameSelect?.options[gameSelect.selectedIndex]?.text || 'Selected Game';
-        title = `No ${gameName} Events in ${seasonName}`;
-        text = `No events found for ${gameName} in ${seasonName}.`;
-    }
-
-    emptyStateTitle.textContent = title;
-    emptyStateText.textContent = text;
-}
-
-// Filter events by type (called when type dropdown changes)
-function filterEventsByType() {
-    const typeFilterSelect = document.getElementById('eventTypeFilter');
-    if (typeFilterSelect?.value) {
-        loadEvents();
-    }
-}
-
-// Filter events by game (called when game dropdown changes)
-function filterEventsByGame() {
-    const gameFilterSelect = document.getElementById('gameFilter');
-    if (gameFilterSelect?.value || EventState.selectedGame) {
-        loadEvents();
-    }
-}
-
-// ============================================
-// EVENT RENDERING
-// ============================================
-function renderEvents(events, isAdmin, isGm) {
-    const containerDiv = document.getElementById('eventsContainer');
-    const emptyStateDiv = document.getElementById('eventsEmptyState');
-
-    if (events.length === 0) {
-        setElementDisplay(containerDiv, 'none');
-        setElementDisplay(emptyStateDiv, 'block');
-        updateEmptyStateMessage();
-        return;
-    }
-
-    const gridHTML = `<div class="events-grid">${
-        events.map(event => createEventCard(event, isAdmin, isGm)).join('')
-    }</div>`;
-
-    containerDiv.innerHTML = gridHTML;
-    setElementDisplay(containerDiv, 'grid');
-
-    // Open detail panel on card click (not the modal)
-    containerDiv.querySelectorAll('.event-card').forEach(card => {
-        card.addEventListener('click', (e) => {
-            openEventDetailPanel(parseInt(card.dataset.eventId));
-        });
-    });
-
-    // Dynamically match list pane scroll height to detail pane
-    const detailPane = document.getElementById('eventsDetailPane');
-    const listPane = document.querySelector('.events-list-pane');
-    if (detailPane && listPane) {
-        if (window._detailPaneObserver) window._detailPaneObserver.disconnect();
-        window._detailPaneObserver = new ResizeObserver(() => {
-            listPane.style.maxHeight = '';
-            const detailHeight = detailPane.offsetHeight;
-            const cap = window.innerHeight - 260;
-            listPane.style.maxHeight = Math.max(detailHeight, cap) + 'px';
-        });
-        window._detailPaneObserver.observe(detailPane);
-    }
-
-    setElementDisplay(containerDiv, 'block');
-    setElementDisplay(emptyStateDiv, 'none');
-}
-
-// Builds individual event cards
-function createEventCard(event, isAdmin, isGm) {
-    const canDelete = canUserDeleteEvent(event);
-    const ongoingIndicator = event.is_ongoing
-        ? '<div class="event-ongoing-indicator" title="Event is currently ongoing"></div>'
-        : '';
-
-    const gameDisplay = formatGameDisplay(event.game, event.team_name, event.is_scheduled);
-    const eventTypeClass = (event.event_type || 'event').toLowerCase();
-    const scheduledClass = event.is_scheduled ? 'scheduled-event' : '';
-    const timeDisplay = event.start_time ? event.start_time : '';
-
-    return `
-        <div class="event-card ${scheduledClass}" data-event-type="${eventTypeClass}" data-event-id="${event.id}" ...>
-            ${ongoingIndicator}
-            <div class="event-card-top">
-                <span class="event-card-name">${event.name}</span>
-                <span class="event-card-game">${gameDisplay}</span>
-            </div>
-            <div class="event-card-bottom">
-                <span class="event-card-date"><i class="fas fa-calendar"></i>${event.date}</span>
-                ${timeDisplay ? `<span class="event-card-time">${timeDisplay}</span>` : ''}
-            </div>
-        </div>
-    `;
-}
-
-// Look up a game's abbreviation from the cached games list
-function getGameAbbreviation(title) {
-    const game = EventState.gamesListCache?.find(g => g.GameTitle === title);
-    return game?.Abbreviation || title; // fall back to full title if not found/not loaded yet
-}
-
-// Format game display: first game's abbreviation, plus a count of any others
-function formatGameDisplay(gameStr, teamName, isScheduled) {
-    if (isScheduled && teamName) return teamName;
-    if (!gameStr || gameStr === 'N/A') return '';
-
-    const games = gameStr.split(', ').map(getGameAbbreviation);
-    return games.length > 1 ? `${games[0]} +${games.length - 1}` : games[0];
-}
-
-// Update empty state message based on current filter
-function updateEmptyStateMessage() {
-    const emptyStateDiv = document.getElementById('eventsEmptyState');
-    const filterSelect = document.getElementById('eventFilter');
-    const filterValue = filterSelect?.value || 'all';
-
-    const emptyStateTitle = emptyStateDiv.querySelector('h3');
-    const emptyStateText = emptyStateDiv.querySelector('p');
-
-    if (!emptyStateTitle || !emptyStateText) return;
-
-    // Get filter-specific messages
-    const message = getEmptyStateMessage(filterValue);
-    emptyStateTitle.textContent = message.title;
-    emptyStateText.textContent = message.text;
-}
+/* ==============================
+   State Messages
+   ============================== */
 
 // Get empty state message based on filter type
 function getEmptyStateMessage(filterValue) {
+     if (PastSeasonFilterState.isFilteringPastSeason) {
+        const seasonName = PastSeasonFilterState.selectedSeasonName;
+        const secondaryFilter = PastSeasonFilterState.secondaryFilter;
+
+        if (secondaryFilter === 'created_by_me') {
+            return { title: `No Events Created in ${seasonName}`, text: `You haven't created any events in ${seasonName}.` };
+        } else if (secondaryFilter === 'type') {
+            const typeSelect = document.getElementById('eventTypeFilter');
+            const typeName = typeSelect?.options[typeSelect.selectedIndex]?.text || 'Selected';
+            return { title: `No ${typeName} Events in ${seasonName}`, text: `No ${typeName.toLowerCase()} events found in ${seasonName}.` };
+        } else if (secondaryFilter === 'game') {
+            const gameSelect = document.getElementById('gameFilter');
+            const gameName = gameSelect?.options[gameSelect.selectedIndex]?.text || 'Selected Game';
+            return { title: `No ${gameName} Events in ${seasonName}`, text: `No events found for ${gameName} in ${seasonName}.` };
+        }
+        return { title: `No Events in ${seasonName}`, text: `No events found for ${seasonName}.` };
+    }
+
     const messages = {
         subscribed: {
             title: 'No Subscribed Events',
@@ -1139,840 +1726,17 @@ function getEmptyStateMessage(filterValue) {
     };
 }
 
-// Show error state when events fail to load
-function showEventsError() {
-    const containerDiv = document.getElementById('eventsContainer');
-    if (!containerDiv) return;
-
-    containerDiv.innerHTML = `
-        <div class="events-info-message">
-            <i class="fas fa-exclamation-circle"></i>
-            <p>Failed to load events. Please refresh the page to try again.</p>
-        </div>
-    `;
-    setElementDisplay(containerDiv, 'block');
-}
-
-// Populate the right-hand detail panel when a card is clicked
-async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetchedBannerData = null) {
-    const pane = document.getElementById('eventsDetailPane');
-    if (window.innerWidth <= 768) {
-        pane.classList.add('sheet-open');
-        document.getElementById('sheetBackdrop')?.classList.add('open');
-        document.body.style.overflow = 'hidden';
-    }
-    EventState.currentEventId = eventId;
-
-    // Show loading state
-    pane.innerHTML = `
-        <div class="events-detail-placeholder">
-            <i class="fas fa-spinner fa-spin"></i>
-            <p>Loading event...</p>
-        </div>
-    `;
-
-    try {
-        const response = prefetchedEventData
-            ? { ok: true, json: () => prefetchedEventData }
-            : await fetch(`/api/event/${eventId}`);
-        if (!response.ok) throw new Error('Failed to fetch event');
-        const event = await response.json();
-        EventState.currentEventData = event;
-
-        const eventTypeClass = (event.event_type || 'event').toLowerCase();
-
-        // Build detail rows
-        const rows = [];
-
-        if (event.start_time) {
-            const timeStr = `${event.start_time}${event.end_time ? ' – ' + event.end_time : ''}`;
-            rows.push(detailRow('clock', 'Time', timeStr));
-        }
-
-        if (event.game && event.game !== 'N/A') {
-            rows.push(detailRow('gamepad', 'Game', event.game));
-        }
-
-        if (event.event_type === 'Match' && event.league_name) {
-            rows.push(detailRow('trophy', 'League', event.league_name));
-        }
-
-        if (event.location) {
-            rows.push(detailRow('map-marker-alt', 'Location', event.location));
-        }
-
-        if (event.description) {
-            rows.push(detailRow('info-circle', 'Description', event.description));
-        }
-
-        // Fetch banner and event data concurrently
-        const [bannerData] = await Promise.all([
-            prefetchedBannerData ||
-                fetch(`/api/event/${eventId}/games`).then(r => r.json()).catch(() => ({ success: false, games: [] }))
-        ]);
-
-        const banners = bannerData.success
-            ? (bannerData.games || []).filter(g => g.GameBanner).map(g => g.GameBanner)
-            : [];
-
-        const bannerHTML = banners.length
-            ? banners.map((url, i) => `
-                <img src="${url}" class="event-detail-banner-img event-detail-banner-slide ${i === 0 ? 'active' : ''}"
-                     alt="Game banner ${i + 1}">
-              `).join('')
-            : '';
-
-        pane.innerHTML = `
-            <div class="events-detail-panel" data-event-type="${eventTypeClass}">
-                <div class="events-detail-banner-wrapper">
-                    <div class="events-detail-banner" id="eventDetailBanner" ${!banners.length ? 'style="display:none"' : ''}>
-                        ${bannerHTML}
-                    </div>
-                    <div class="events-detail-banner-actions">
-                        ${canUserEditEvent(event) ? `
-                            <button class="events-detail-banner-btn" title="Edit event"
-                                    onclick="togglePanelEditMode()">
-                                <i class="fas fa-edit"></i>
-                            </button>` : ''}
-                        ${canUserDeleteEvent(event) ? `
-                            <button class="events-detail-banner-btn delete" title="Delete event"
-                                    onclick="openDeleteEventModal(${event.id}, '${escapeQuotes(event.name)}')">
-                                <i class="fas fa-trash"></i>
-                            </button>` : ''}
-                    </div>
-                </div>
-                <h2 class="events-detail-title">${event.name}</h2>
-                <div class="events-detail-sections">
-                    <div class="events-detail-row">
-                        <div class="event-detail-icon"><i class="fas fa-calendar-alt"></i></div>
-                        <div class="events-detail-row-text">
-                            <h4>Date</h4>
-                            <p>${event.date}</p>
-                        </div>
-                        <span class="game-next-event-type ${eventTypeClass} events-detail-type-badge">${event.event_type || 'Event'}</span>
-                    </div>
-                    ${rows.join('')}
-                </div>
-                <div class="notification-opt-in">
-                    <div class="notification-icon"><i class="fas fa-bell"></i></div>
-                    <div class="notification-text">
-                        <div class="title">Event Reminders</div>
-                        <div class="subtitle">Get notified about this event</div>
-                    </div>
-                    <button class="notification-btn" id="detailSubscribeBtn"
-                            onclick="toggleEventSubscription()">
-                        <span id="detailSubscribeBtnText">Loading...</span>
-                    </button>
-                </div>
-            </div>
-        `;
-
-        // Re-apply scroll lock on mobile after innerHTML replacement
-        if (window.innerWidth <= 768) {
-            document.body.style.overflow = 'hidden';
-        }
-
-        // Now load the notification section
-        await loadNotificationSection(eventId);
-
-        // Start slideshow if multiple banners
-        if (banners.length > 1) {
-            const bannerEl = document.getElementById('eventDetailBanner');
-            let current = 0;
-            const slides = bannerEl.querySelectorAll('.event-detail-banner-slide');
-            clearInterval(bannerEl._slideInterval);
-            bannerEl._slideInterval = setInterval(() => {
-                slides[current].classList.remove('active');
-                current = (current + 1) % slides.length;
-                slides[current].classList.add('active');
-            }, 3500);
-        }
-
-    } catch (error) {
-        console.error('Error loading event detail panel:', error);
-        pane.innerHTML = `
-            <div class="events-detail-placeholder">
-                <i class="fas fa-exclamation-circle"></i>
-                <p>Failed to load event details.</p>
-            </div>
-        `;
-    }
-}
-
-// Load banners to display with event detail panel
-async function loadEventBanner(eventId) {
-    const bannerEl = document.getElementById('eventDetailBanner');
-    if (!bannerEl) return;
-
-    try {
-        const response = await fetch(`/api/event/${eventId}/games`);
-        const data = await response.json();
-
-        if (!data.success || !data.games?.length) {
-            bannerEl.style.display = 'none';
-            return;
-        }
-
-        const banners = data.games
-            .filter(g => g.GameBanner)
-            .map(g => g.GameBanner);
-
-        if (!banners.length) {
-            bannerEl.style.display = 'none';
-            return;
-        }
-
-        if (banners.length === 1) {
-            bannerEl.innerHTML = `<img src="${banners[0]}" class="event-detail-banner-img" alt="Game banner">`;
-            return;
-        }
-
-        bannerEl.innerHTML = banners.map((url, i) => `
-            <img src="${url}" class="event-detail-banner-img event-detail-banner-slide ${i === 0 ? 'active' : ''}"
-                 alt="Game banner ${i + 1}">
-        `).join('');
-
-        let current = 0;
-        const slides = bannerEl.querySelectorAll('.event-detail-banner-slide');
-        clearInterval(bannerEl._slideInterval);
-        bannerEl._slideInterval = setInterval(() => {
-            slides[current].classList.remove('active');
-            current = (current + 1) % slides.length;
-            slides[current].classList.add('active');
-        }, 3500);
-
-    } catch (err) {
-        console.error('Error loading event banner:', err);
-    }
-}
-
-// Build a single detail row for the panel
-function detailRow(icon, label, value) {
-    return `
-        <div class="events-detail-row">
-            <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
-            <div class="events-detail-row-text">
-                <h4>${label}</h4>
-                <p>${value}</p>
-            </div>
-        </div>
-    `;
-}
-
-// Enables and disables event detail panel editing
-function togglePanelEditMode() {
-    const event = EventState.currentEventData;
-    if (!event) return;
-
-    // Replace title with input
-    const title = document.querySelector('.events-detail-panel .events-detail-title');
-    if (title) {
-        title.outerHTML = `<input id="panelEditName" class="events-detail-title panel-edit-input"
-                                  value="${escapeQuotes(event.name || '')}" type="text">`;
-    }
-
-    // Inject missing rows in correct order before transforming
-    const sections = document.querySelector('.events-detail-panel .events-detail-sections');
-    const existingLabels = [...sections.querySelectorAll('h4')].map(h => h.textContent.trim());
-
-    // Full ordered field list — Date is always present, skip Game for scheduled events
-    const allRows = [
-        { label: 'Time',        icon: 'clock'          },
-        ...(!event.is_scheduled ? [{ label: 'Game', icon: 'gamepad' }] : []),
-        { label: 'Location',    icon: 'map-marker-alt' },
-        { label: 'Description', icon: 'info-circle'    },
-    ];
-
-    // Insert missing rows in order relative to existing ones
-    allRows.forEach(({ label, icon }) => {
-        if (existingLabels.includes(label)) return;
-
-        // Find the row that should come after this one, insert before it
-        const allLabels = ['Date', 'Time', 'Game', 'Location', 'Description'];
-        const afterIndex = allLabels.indexOf(label);
-        let inserted = false;
-
-        for (let i = afterIndex + 1; i < allLabels.length; i++) {
-            const nextLabel = allLabels[i];
-            const nextRow = [...sections.querySelectorAll('.events-detail-row')]
-                .find(r => r.querySelector('h4')?.textContent.trim() === nextLabel);
-            if (nextRow) {
-                nextRow.insertAdjacentHTML('beforebegin', `
-                    <div class="events-detail-row">
-                        <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
-                        <div class="events-detail-row-text"><h4>${label}</h4><p></p></div>
-                    </div>
-                `);
-                inserted = true;
-                break;
-            }
-        }
-
-        // If no later row exists, append at end
-        if (!inserted) {
-            sections.insertAdjacentHTML('beforeend', `
-                <div class="events-detail-row">
-                    <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
-                    <div class="events-detail-row-text"><h4>${label}</h4><p></p></div>
-                </div>
-            `);
-        }
-    });
-
-    // Transform all rows to editable inputs
-    document.querySelectorAll('.events-detail-panel .events-detail-row').forEach(row => {
-        const label = row.querySelector('h4')?.textContent?.trim();
-        const valueEl = row.querySelector('p');
-        if (!valueEl) return;
-
-        switch (label) {
-            case 'Date':
-                valueEl.outerHTML = `<input id="panelEditDate" class="panel-edit-input"
-                                            type="date" value="${event.date_raw || ''}">`;
-                break;
-            case 'Time':
-                valueEl.outerHTML = `<div class="panel-edit-time-row">
-                    <input id="panelEditStartTime" class="panel-edit-input"
-                           type="time" value="${convertTo24Hour(event.start_time)}">
-                    <span>–</span>
-                    <input id="panelEditEndTime" class="panel-edit-input"
-                           type="time" value="${convertTo24Hour(event.end_time)}">
-                </div>`;
-                break;
-            case 'Game':
-                if (event.is_scheduled) break;
-                valueEl.outerHTML = `
-                    <div>
-                        <div id="editSelectedGamesContainer" class="selected-games-container"></div>
-                        <select id="editGameDropdown" class="panel-edit-input">
-                            <option value="">+ Add a game</option>
-                        </select>
-                        <div id="editGameLoadingIndicator" style="display:none; font-size:0.8125rem; color:var(--text-secondary); margin-top:0.5rem;">
-                            <i class="fas fa-spinner fa-spin"></i> Loading games...
-                        </div>
-                        <input type="hidden" id="editSelectedGamesInput" name="games" value="[]">
-                    </div>
-                `;
-                break;
-            case 'Location':
-                valueEl.outerHTML = `<select id="panelEditLocation" class="panel-edit-input">
-                    <option value="Campus Center" ${event.location === 'Campus Center' ? 'selected' : ''}>Campus Center</option>
-                    <option value="Campus Center Coffee House" ${event.location === 'Campus Center Coffee House' ? 'selected' : ''}>Campus Center Coffee House</option>
-                    <option value="Campus Center Event Room" ${event.location === 'Campus Center Event Room' ? 'selected' : ''}>Campus Center Event Room</option>
-                    <option value="D-108" ${event.location === 'D-108' ? 'selected' : ''}>D-108</option>
-                    <option value="Esports Lab (Commons Building 80)" ${event.location === 'Esports Lab (Commons Building 80)' ? 'selected' : ''}>Esports Lab</option>
-                    <option value="Lakeside Lodge" ${event.location === 'Lakeside Lodge' ? 'selected' : ''}>Lakeside Lodge</option>
-                    <option value="Online" ${event.location === 'Online' ? 'selected' : ''}>Online</option>
-                </select>`;
-                break;
-            case 'Description':
-                valueEl.outerHTML = `<textarea id="panelEditDescription" class="panel-edit-input"
-                                               rows="3">${event.description || ''}</textarea>`;
-                break;
-        }
-    });
-
-    // Initialize game editable field if not scheduled event
-    if (!event.is_scheduled) {
-        initializeGameTagSelector('edit', event.game);
-    }
-
-    //Attach description character counter
-    attachCharacterCounter('panelEditDescription', 250);
-
-    // Swap edit button for save/cancel
-    const editBtn = document.querySelector('.events-detail-banner-btn:not(.delete)');
-    if (editBtn) {
-        editBtn.outerHTML = `
-            <button class="events-detail-banner-btn panel-save-btn" onclick="submitPanelEdit()" title="Save changes">
-                <i class="fas fa-check"></i>
-            </button>
-            <button class="events-detail-banner-btn panel-cancel-btn" onclick="cancelPanelEdit()" title="Cancel">
-                <i class="fas fa-times"></i>
-            </button>
-        `;
-    }
-}
-
-// Cancel editing in the event detail panel
-function cancelPanelEdit() {
-    if (EventState.currentEventId) {
-        openEventDetailPanel(EventState.currentEventId);
-    }
-}
-
-// Confirms edits made in the event detail panel
-async function submitPanelEdit() {
-    const nameInput = document.getElementById('panelEditName');
-    if (!nameInput?.value?.trim()) {
-        nameInput?.classList.add('panel-edit-input-error');
-        nameInput?.focus();
-        return;
-    }
-    nameInput.classList.remove('panel-edit-input-error');
-
-    const saveBtn = document.querySelector('.panel-save-btn');
-    if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
-
-    const locationSelect = document.getElementById('panelEditLocation');
-
-    const formData = {
-        event_id: EventState.currentEventId,
-        event_name: document.getElementById('panelEditName')?.value,
-        event_type: EventState.currentEventData?.event_type,
-        games: document.getElementById('editSelectedGamesInput')?.value ||
-                JSON.stringify(EventState.currentEventData?.game ? [EventState.currentEventData.game] : []),
-        event_date: document.getElementById('panelEditDate')?.value,
-        start_time: document.getElementById('panelEditStartTime')?.value,
-        end_time: document.getElementById('panelEditEndTime')?.value,
-        location: locationSelect?.value,
-        description: document.getElementById('panelEditDescription')?.value,
-        league_id: EventState.currentEventData?.league_id || null
-    };
-
-    try {
-        const response = await fetch('/api/event/edit', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(formData)
-        });
-        const data = await response.json();
-
-        if (data.success) {
-            // Refresh the panel and card with updated data
-            await openEventDetailPanel(EventState.currentEventId);
-            loadEvents();
-        } else {
-            throw new Error(data.message || 'Failed to update event');
-        }
-    } catch (error) {
-        console.error('Error saving event:', error);
-        if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-check"></i>';
-        alert(error.message || 'Failed to save changes.');
-    }
-}
-
-// Handle event load error
-function handleEventLoadError(titleElement, content, spinner) {
-    if (titleElement) {
-        titleElement.textContent = 'Error Loading Event';
-    }
-
-    content.innerHTML = `
-        <div style="text-align: center; padding: 2rem; color: var(--text-secondary);">
-            <i class="fas fa-exclamation-circle" style="font-size: 2rem; color: #ff5252; margin-bottom: 1rem;"></i>
-            <p>Failed to load event details. Please try again.</p>
-            <button class="btn btn-primary" onclick="closeEventModal()" style="margin-top: 1rem;">Close</button>
-        </div>
-    `;
-
-    setElementDisplay(spinner, 'none');
-    setElementDisplay(content, 'block');
-}
-
-// Closes the event detail pane in mobile view
-function closeEventDetailSheet() {
-    const pane = document.getElementById('eventsDetailPane');
-    pane?.classList.remove('sheet-open');
-    document.getElementById('sheetBackdrop')?.classList.remove('open');
-    document.body.style.overflow = '';
-}
-
-// ============================================
-// CREATE EVENT MODAL
-// ============================================
-function openCreateEventModal() {
-    const modal = document.getElementById('createEventModal');
-    const form = document.getElementById('createEventForm');
-    const customLocationGroup = document.getElementById('customLocationGroup');
-    const formMessage = document.getElementById('formMessage');
-    const leagueGroup = document.getElementById('eventLeagueFieldGroup');
-
-    // Show modal
-    setElementDisplay(modal, 'block');
-    document.body.style.overflow = 'hidden';
-
-    // Reset form and state
-    form.reset();
-    setElementDisplay(customLocationGroup, 'none');
-    setElementDisplay(formMessage, 'none');
-    setElementDisplay(leagueGroup, 'none');
-    clearSelectedGames('create');
-    
-    // Character Counter
-    attachCharacterCounter('eventDescription', 250);
-
-    // Load games after modal is rendered
-    setTimeout(() => {
-        const dropdown = document.getElementById('gameDropdown');
-        if (dropdown) {
-            enableDropdown(dropdown);
-        }
-        initializeGameTagSelector('create');
-    }, 50);
-}
-
-// Close create event modal
-function closeCreateEventModal() {
-    const modal = document.getElementById('createEventModal');
-    setElementDisplay(modal, 'none');
-    document.body.style.overflow = 'auto';
-}
-
-// Handle location dropdown change
-function handleLocationChange(e) {
-    const customLocationGroup = document.getElementById('customLocationGroup');
-    const customLocationInput = document.getElementById('customLocation');
-
-    if (e.target.value === 'other') {
-        setElementDisplay(customLocationGroup, 'block');
-        customLocationInput.required = true;
-    } else {
-        setElementDisplay(customLocationGroup, 'none');
-        customLocationInput.required = false;
-        customLocationInput.value = '';
-    }
-}
-
-// Handle event type change - hide game field for Misc events
-function handleEventTypeChange() {
-    const eventType = document.getElementById('eventType')?.value;
-    const gameFieldGroup = document.getElementById('gameFieldGroup');
-
-    // Handle game field visibility for Misc events
-    if (eventType === 'Misc') {
-        setElementDisplay(gameFieldGroup, 'none');
-        clearSelectedGames('create');
-    } else {
-        setElementDisplay(gameFieldGroup, 'block');
-    }
-}
-
-// Toggle all-day event button
-function toggleAllDayEvent() {
-    const allDayCheckbox = document.getElementById('allDayEvent');
-    const allDayButton = document.getElementById('allDayButton');
-    const startTimeInput = document.getElementById('startTime');
-    const endTimeInput = document.getElementById('endTime');
-
-    if (!allDayCheckbox || !allDayButton || !startTimeInput || !endTimeInput) return;
-
-    // Toggle checkbox state
-    allDayCheckbox.checked = !allDayCheckbox.checked;
-
-    if (allDayCheckbox.checked) {
-        // Activate all-day mode
-        allDayButton.textContent = 'ALL DAY';
-        allDayButton.classList.add('active');
-
-        // Set all-day times
-        startTimeInput.value = '00:00';
-        endTimeInput.value = '23:59';
-
-        // Make inputs read-only
-        startTimeInput.readOnly = true;
-        endTimeInput.readOnly = true;
-        startTimeInput.style.opacity = '0.5';
-        endTimeInput.style.opacity = '0.5';
-
-        // Remove required attribute
-        startTimeInput.removeAttribute('required');
-        endTimeInput.removeAttribute('required');
-    } else {
-        // Deactivate all-day mode
-        allDayButton.textContent = 'ALL DAY?';
-        allDayButton.classList.remove('active');
-
-        // Clear times
-        startTimeInput.value = '';
-        endTimeInput.value = '';
-
-        // Enable inputs
-        startTimeInput.readOnly = false;
-        endTimeInput.readOnly = false;
-        startTimeInput.style.opacity = '1';
-        endTimeInput.style.opacity = '1';
-
-        // Add required attribute back
-        startTimeInput.setAttribute('required', 'required');
-        endTimeInput.setAttribute('required', 'required');
-    }
-}
-
-// Handle create event form submission
-async function handleCreateEventSubmit(e) {
-    e.preventDefault();
-
-    const submitBtn = e.target.querySelector('button[type="submit"]');
-    const submitBtnText = document.getElementById('submitBtnText');
-    const submitBtnSpinner = document.getElementById('submitBtnSpinner');
-    const formMessage = document.getElementById('formMessage');
-
-    // Validate league for Match events
-    const eventType = document.getElementById('eventType')?.value;
-    const leagueDropdown = document.getElementById('eventLeagueDropdown');
-    
-    if (eventType === 'Match' && (!leagueDropdown?.value)) {
-        formMessage.textContent = 'Please select a league for Match events.';
-        formMessage.className = 'form-message error';
-        formMessage.style.display = 'block';
-        return;
-    }
-
-    // Set loading state
-    submitBtn.disabled = true;
-    setElementDisplay(submitBtnText, 'none');
-    setElementDisplay(submitBtnSpinner, 'inline-block');
-
-    const formData = new FormData(e.target);
-
-    // Handle custom location
-    const location = formData.get('eventLocation');
-    if (location === 'other') {
-        formData.set('eventLocation', formData.get('customLocation'));
-    }
-    formData.delete('customLocation');
-
-    try {
-        const response = await fetch('/event-register', {
-            method: 'POST',
-            headers: { 'X-Requested-With': 'XMLHttpRequest' },
-            body: formData
-        });
-
-        const data = await response.json();
-
-        if (response.ok && data.success) {
-            // Direct manipulation
-            formMessage.innerHTML = (data.message || 'Event created successfully! Refreshing calendar...').replace(/\n/g, '<br>');
-            formMessage.className = 'form-message success';
-            formMessage.style.display = 'block';
-
-            setTimeout(() => window.location.reload(), 350);
-        } else {
-            throw new Error(data.message || 'Failed to create event');
-        }
-    } catch (error) {
-        // Direct manipulation for error
-        formMessage.textContent = error.message || 'Failed to create event. Please try again.';
-        formMessage.className = 'form-message error';
-        formMessage.style.display = 'block';
-
-        // Reset button state
-        submitBtn.disabled = false;
-        setElementDisplay(submitBtnText, 'inline');
-        setElementDisplay(submitBtnSpinner, 'none');
-    }
-}
-
-// ============================================
-// DAY MODAL (CALENDAR VIEW)
-// ============================================
-function openDayModal(date, dateTitle) {
-    const modal = document.getElementById('dayEventsModal');
-    const modalTitle = document.getElementById('modalDayTitle');
-    const modalBody = document.getElementById('modalEventsList');
-
-    modalTitle.textContent = dateTitle;
-    const events = EventState.eventsData[date] || [];
-
-    // Clear and populate modal body
-    modalBody.innerHTML = '';
-
-    if (events.length > 0) {
-        events.forEach(event => {
-            const eventItem = createDayModalEventItem(event);
-            modalBody.appendChild(eventItem);
-        });
-    } else {
-        modalBody.innerHTML = '<p style="color: var(--text-secondary); text-align: center;">No events scheduled for this day.</p>';
-    }
-
-    setElementDisplay(modal, 'block');
-    document.body.style.overflow = 'hidden';
-}
-
-// Create event item for day modal
-function createDayModalEventItem(event) {
-    const eventItem = document.createElement('div');
-    eventItem.className = 'modal-event-item';
-    eventItem.onclick = (e) => {
-        e.stopPropagation();
-        closeDayModal();
-        openEventModal(event.id);
-    };
-
-    let eventHTML = '';
-    if (event.time) {
-        eventHTML += `<div class="modal-event-time"><i class="fas fa-clock"></i> ${event.time}</div>`;
-    }
-    eventHTML += `<div class="modal-event-title">${event.title}</div>`;
-    if (event.description) {
-        eventHTML += `<div class="modal-event-description">${event.description}</div>`;
-    }
-
-    eventItem.innerHTML = eventHTML;
-    return eventItem;
-}
-
-// Close day modal
-function closeDayModal() {
-    const modal = document.getElementById('dayEventsModal');
-    setElementDisplay(modal, 'none');
-    document.body.style.overflow = 'auto';
-}
-
-// ============================================
-// DELETE EVENT
-// ============================================
-async function openDeleteEventModal(eventId, eventName) {
-    EventState.currentDeleteEventId = eventId;
-    EventState.currentDeleteEventName = eventName;
-
-    // Fetch event data if needed
-    if (!EventState.currentEventData || EventState.currentEventData.id !== eventId) {
-        try {
-            const response = await fetch(`/api/event/${eventId}`);
-            if (!response.ok) throw new Error('Failed to fetch event details');
-            EventState.currentEventData = await response.json();
-        } catch (error) {
-            console.error('Error fetching event data for deletion:', error);
-        }
-    }
-
-    const eventData = EventState.currentEventData;
-    const isDeveloper = window.userPermissions?.is_developer || false;
-    const timeRemaining = eventData ? getDeletionTimeRemaining(eventData.created_at) : null;
-
-    // Build additional info for time window
-    let additionalInfo = '';
-    if (!isDeveloper && timeRemaining) {
-        additionalInfo = `
-            <div style="margin-top: 1rem; padding: 0.75rem; background: rgba(251, 191, 36, 0.1);
-                        border: 1px solid #fbbf24; border-radius: 6px; font-size: 0.875rem;">
-                <i class="fas fa-clock" style="color: #fbbf24;"></i>
-                <strong style="color: #fbbf24;">Deletion window:</strong> ${timeRemaining}
-            </div>
-        `;
-    }
-
-    // Open universal modal with event-specific config
-    window.openDeleteConfirmModal({
-        title: 'Delete Event?',
-        itemName: eventName,
-        message: `Are you sure you want to delete ${eventName}? This action cannot be undone.`,
-        additionalInfo: additionalInfo,
-        buttonText: 'Delete Event',
-        onConfirm: confirmDeleteEvent,
-        itemId: eventId
-    });
-}
-
-// Function triggered when an event is confirmed to be deleted
-async function confirmDeleteEvent(eventId) {
-    try {
-        const response = await fetch(`/api/events/${eventId}`, {
-            method: 'DELETE',
-            headers: { 'Content-Type': 'application/json' }
-        });
-
-        const data = await response.json();
-
-        if (data.success) {
-            window.closeDeleteConfirmModal();
-
-            // If deletion was from event modal, close that too
-            if (EventState.deletionFromModal) {
-                const eventModal = document.getElementById('eventDetailsModal');
-                if (eventModal) {
-                    eventModal.style.display = 'none';
-                }
-                EventState.deletionFromModal = false;
-            }
-
-            // Show success notification FIRST
-            showDeleteSuccessMessage(data.message);
-
-            // If schedule was auto-deleted, show additional notification with proper delay
-            if (data.schedule_deleted && data.schedule_name) {
-                // Wait for first notification to appear and settle
-                setTimeout(() => {
-                    if (typeof window.showInfoMessage === 'function') {
-                        window.showInfoMessage(
-                            `Schedule "${data.schedule_name}" was automatically removed (no events remaining)`,
-                            4000
-                        );
-                    } else if (typeof window.showScheduleCleanupNotification === 'function') {
-                        window.showScheduleCleanupNotification(data.schedule_name);
-                    }
-                }, 600); // Increased delay to ensure proper stacking
-            }
-
-            // Route based on deletion source
-            setTimeout(() => {
-                if (EventState.deletionSource === 'events') {
-                    // Reload events tab only
-                    loadEvents();
-                    // Manually restore scrolling
-                    document.body.style.overflow = 'auto';
-                } else {
-                    // Calendar view - ALWAYS full page reload
-                    window.location.reload();
-                }
-            }, data.schedule_deleted ? 2000 : 1000); // Longer delay if showing two notifications
-        } else {
-            handleDeleteError(data.message);
-        }
-    } catch (error) {
-        console.error('Error deleting event:', error);
-        showDeleteErrorMessage('An error occurred while deleting the event');
-        window.closeDeleteConfirmModal();
-    }
-}
-
-// Handle delete error messages
-function handleDeleteError(message) {
-    window.closeDeleteConfirmModal();
-
-    if (message.includes('expired') || message.includes('24')) {
-        showDeleteErrorMessage(`⏰ ${message}\n\nOnly developers can delete events after 24 hours.`);
-    } else if (message.includes('creator')) {
-        showDeleteErrorMessage(`🚫 ${message}`);
-    } else {
-        showDeleteErrorMessage('Error: ' + message);
-    }
-}
-
-// Delete event (called from event details modal)
-async function deleteEvent() {
-    if (!EventState.currentEventId) {
-        alert("Event ID not found.");
-        return;
-    }
-
-    const event = EventState.currentEventData;
-    if (!event) {
-        alert("Event data not found.");
-        return;
-    }
-
-    // Check if user can delete
-    if (!canUserDeleteEvent(event)) {
-        const is_developer = window.userPermissions?.is_developer || false;
-
-        if (!is_developer && event.created_by === (window.currentUserId || 0)) {
-            alert("⏰ The 24-hour deletion window has expired.\n\nOnly developers can delete events after 24 hours.");
-        } else {
-            alert("🚫 You don't have permission to delete this event.");
-        }
-        return;
-    }
-
-    // Track that deletion was initiated from modal
-    EventState.deletionFromModal = true;
-
-    // DON'T close the event modal - just open delete confirmation on top
-    openDeleteEventModal(event.id, event.name);
+// Update empty state message based on current filter
+function updateEmptyStateMessage() {
+    const emptyStateDiv = document.getElementById('eventsEmptyState');
+    const emptyStateTitle = emptyStateDiv?.querySelector('h3');
+    const emptyStateText = emptyStateDiv?.querySelector('p');
+    if (!emptyStateTitle || !emptyStateText) return;
+
+    const filterValue = document.getElementById('eventFilter')?.value || 'all';
+    const message = getEmptyStateMessage(filterValue);
+    emptyStateTitle.textContent = message.title;
+    emptyStateText.textContent = message.text;
 }
 
 // ============================================
@@ -1987,24 +1751,6 @@ function setElementDisplay(element, displayValue) {
 // Escape single quotes in strings for safe HTML attribute use
 function escapeQuotes(str) {
     return str.replace(/'/g, "\\'");
-}
-
-// Convert 12-hour time format to 24-hour format for input[type="time"]
-function convertTo24Hour(time12h) {
-    if (!time12h) return '';
-
-    const [time, period] = time12h.split(' ');
-    let [hours, minutes] = time.split(':');
-
-    hours = parseInt(hours);
-
-    if (period === 'PM' && hours !== 12) {
-        hours += 12;
-    } else if (period === 'AM' && hours === 12) {
-        hours = 0;
-    }
-
-    return `${hours.toString().padStart(2, '0')}:${minutes}`;
 }
 
 // Determines from which direction the event filter submenu pops out from
@@ -2024,15 +1770,25 @@ function positionFlyout(triggerEl) {
     flyout.style.display = '';
 }
 
+// Builds a loading state for events
+function showEventsLoadingState() {
+    setElementDisplay(document.getElementById('eventsLoading'), 'block');
+    setElementDisplay(document.getElementById('eventsContainer'), 'none');
+    setElementDisplay(document.getElementById('eventsEmptyState'), 'none');
+}
+
+// Hides the loading state for events
+function hideEventsLoadingState() {
+    setElementDisplay(document.getElementById('eventsLoading'), 'none');
+}
+
 // ===================================
 // HELPERS
 // ===================================
 
 // Check if current user can delete an event
 function canUserDeleteEvent(event) {
-    const is_developer = window.userPermissions?.is_developer || false;
-    const is_gm = window.userPermissions?.is_gm || false;
-    const is_admin = window.userPermissions?.is_admin || false;
+    const { is_developer, is_gm, is_admin } = EventState.permissions;
     const sessionUserId = window.currentUserId || 0;
 
     // Developers can always delete
@@ -2094,11 +1850,22 @@ function getDeletionTimeRemaining(createdAt) {
 
 // Check if current user can edit an event
 function canUserEditEvent(event) {
-    const is_admin = window.userPermissions?.is_admin || false;
-    const is_developer = window.userPermissions?.is_developer || false;
-    const is_gm = window.userPermissions?.is_gm || false;
+    const { is_admin, is_developer, is_gm } = EventState.permissions;
     const sessionUserId = window.currentUserId || 0;
     return is_admin || is_developer || (is_gm && event.created_by === sessionUserId);
+}
+
+// Loads and activates the banner slideshow system in the event detail pane
+function startBannerSlideshow(bannerEl) {
+    const slides = bannerEl.querySelectorAll('.event-detail-banner-slide');
+    if (slides.length <= 1) return;
+    let current = 0;
+    clearInterval(bannerEl._slideInterval);
+    bannerEl._slideInterval = setInterval(() => {
+        slides[current].classList.remove('active');
+        current = (current + 1) % slides.length;
+        slides[current].classList.add('active');
+    }, 3500);
 }
 
 // ============================================
@@ -2106,26 +1873,21 @@ function canUserEditEvent(event) {
 // ============================================
 window.initializeEventsModule = initializeEventsModule;
 window.loadEvents = loadEvents;
-window.filterEvents = filterEvents;
 
-// Day Modal Functions (Calendar)
-window.openDayModal = openDayModal;
-window.closeDayModal = closeDayModal;
-
-// Create Event Functions
+// Create Event
 window.openCreateEventModal = openCreateEventModal;
 window.closeCreateEventModal = closeCreateEventModal;
 window.handleEventTypeChange = handleEventTypeChange;
 window.toggleAllDayEvent = toggleAllDayEvent;
 
-// Delete Event Functions
+// Delete Event
 window.deleteEvent = deleteEvent;
 
-//Filtering with seasons
+// Filtering
+window.filterEvents = filterEvents;
 window.toggleFilterBox = toggleFilterBox;
-window.handlePastSeasonSelection = handlePastSeasonSelection;
 window.filterEventsByPastSeason = filterEventsByPastSeason;
 
-// Event detail panel opening
+// Event Detail Panel
 window.openEventDetailPanel = openEventDetailPanel;
 window.closeEventDetailSheet = closeEventDetailSheet;

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -96,6 +96,11 @@ function attachEventListeners() {
     // Filter box flyouts
     initPastSeasonsFlyout();
     initGameFlyouts();
+
+    // Determines whether popout should appear to the right or left of the filter dropdown menu
+    document.querySelectorAll('.filter-box-item--flyout').forEach(trigger => {
+    trigger.addEventListener('mouseenter', () => positionFlyout(trigger));
+    });
 }
 
 // ============================================
@@ -2656,6 +2661,22 @@ function canUserEditEvent(event) {
     const is_gm = window.userPermissions?.is_gm || false;
     const sessionUserId = window.currentUserId || 0;
     return is_admin || is_developer || (is_gm && event.created_by === sessionUserId);
+}
+
+function positionFlyout(triggerEl) {
+    const flyout = triggerEl.querySelector('.filter-box-flyout');
+    if (!flyout) return;
+
+    // Reset first so we can measure natural width
+    flyout.classList.remove('flyout-left');
+    flyout.style.display = 'block';
+
+    const rect = flyout.getBoundingClientRect();
+    if (rect.right > window.innerWidth - 8) {
+        flyout.classList.add('flyout-left');
+    }
+
+    flyout.style.display = '';
 }
 
 // ============================================

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -790,6 +790,20 @@ function renderEvents(events, isAdmin, isGm) {
         });
     });
 
+    // Dynamically match list pane scroll height to detail pane
+    const detailPane = document.getElementById('eventsDetailPane');
+    const listPane = document.querySelector('.events-list-pane');
+    if (detailPane && listPane) {
+        if (window._detailPaneObserver) window._detailPaneObserver.disconnect();
+        window._detailPaneObserver = new ResizeObserver(() => {
+            listPane.style.maxHeight = '';
+            const detailHeight = detailPane.offsetHeight;
+            const cap = window.innerHeight - 260;
+            listPane.style.maxHeight = Math.max(detailHeight, cap) + 'px';
+        });
+        window._detailPaneObserver.observe(detailPane);
+    }
+
     setElementDisplay(containerDiv, 'block');
     setElementDisplay(emptyStateDiv, 'none');
 }
@@ -1105,7 +1119,7 @@ async function openEventDetailPanel(eventId) {
                     <div class="events-detail-banner-actions">
                         ${canUserEditEvent(event) ? `
                             <button class="events-detail-banner-btn" title="Edit event"
-                                    onclick="toggleEditMode()">
+                                    onclick="togglePanelEditMode()">
                                 <i class="fas fa-edit"></i>
                             </button>` : ''}
                         ${canUserDeleteEvent(event) ? `
@@ -1202,6 +1216,196 @@ function createNotificationSection() {
             </div>
         </div>
     `;
+}
+
+function togglePanelEditMode() {
+    const event = EventState.currentEventData;
+    if (!event) return;
+
+    // Replace title with input
+    const title = document.querySelector('.events-detail-panel .events-detail-title');
+    if (title) {
+        title.outerHTML = `<input id="panelEditName" class="events-detail-title panel-edit-input"
+                                  value="${escapeQuotes(event.name || '')}" type="text">`;
+    }
+
+    // Inject missing rows in correct order before transforming
+    const sections = document.querySelector('.events-detail-panel .events-detail-sections');
+    const existingLabels = [...sections.querySelectorAll('h4')].map(h => h.textContent.trim());
+
+    // Full ordered field list — Date is always present, skip Game for scheduled events
+    const allRows = [
+        { label: 'Time',        icon: 'clock'          },
+        ...(!event.is_scheduled ? [{ label: 'Game', icon: 'gamepad' }] : []),
+        { label: 'Location',    icon: 'map-marker-alt' },
+        { label: 'Description', icon: 'info-circle'    },
+    ];
+
+    // Insert missing rows in order relative to existing ones
+    allRows.forEach(({ label, icon }) => {
+        if (existingLabels.includes(label)) return;
+
+        // Find the row that should come after this one, insert before it
+        const allLabels = ['Date', 'Time', 'Game', 'Location', 'Description'];
+        const afterIndex = allLabels.indexOf(label);
+        let inserted = false;
+
+        for (let i = afterIndex + 1; i < allLabels.length; i++) {
+            const nextLabel = allLabels[i];
+            const nextRow = [...sections.querySelectorAll('.events-detail-row')]
+                .find(r => r.querySelector('h4')?.textContent.trim() === nextLabel);
+            if (nextRow) {
+                nextRow.insertAdjacentHTML('beforebegin', `
+                    <div class="events-detail-row">
+                        <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
+                        <div class="events-detail-row-text"><h4>${label}</h4><p></p></div>
+                    </div>
+                `);
+                inserted = true;
+                break;
+            }
+        }
+
+        // If no later row exists, append at end
+        if (!inserted) {
+            sections.insertAdjacentHTML('beforeend', `
+                <div class="events-detail-row">
+                    <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
+                    <div class="events-detail-row-text"><h4>${label}</h4><p></p></div>
+                </div>
+            `);
+        }
+    });
+
+    // Transform all rows to editable inputs
+    document.querySelectorAll('.events-detail-panel .events-detail-row').forEach(row => {
+        const label = row.querySelector('h4')?.textContent?.trim();
+        const valueEl = row.querySelector('p');
+        if (!valueEl) return;
+
+        switch (label) {
+            case 'Date':
+                valueEl.outerHTML = `<input id="panelEditDate" class="panel-edit-input"
+                                            type="date" value="${event.date_raw || ''}">`;
+                break;
+            case 'Time':
+                valueEl.outerHTML = `<div class="panel-edit-time-row">
+                    <input id="panelEditStartTime" class="panel-edit-input"
+                           type="time" value="${convertTo24Hour(event.start_time)}">
+                    <span>–</span>
+                    <input id="panelEditEndTime" class="panel-edit-input"
+                           type="time" value="${convertTo24Hour(event.end_time)}">
+                </div>`;
+                break;
+            case 'Game':
+                if (event.is_scheduled) break;
+                valueEl.outerHTML = `
+                    <div>
+                        <div id="editSelectedGamesContainer" class="selected-games-container"></div>
+                        <select id="editGameDropdown" class="panel-edit-input">
+                            <option value="">+ Add a game</option>
+                        </select>
+                        <div id="editGameLoadingIndicator" style="display:none; font-size:0.8125rem; color:var(--text-secondary); margin-top:0.5rem;">
+                            <i class="fas fa-spinner fa-spin"></i> Loading games...
+                        </div>
+                        <input type="hidden" id="editSelectedGamesInput" name="games" value="[]">
+                    </div>
+                `;
+                break;
+            case 'Location':
+                valueEl.outerHTML = `<select id="panelEditLocation" class="panel-edit-input">
+                    <option value="Campus Center" ${event.location === 'Campus Center' ? 'selected' : ''}>Campus Center</option>
+                    <option value="Campus Center Coffee House" ${event.location === 'Campus Center Coffee House' ? 'selected' : ''}>Campus Center Coffee House</option>
+                    <option value="Campus Center Event Room" ${event.location === 'Campus Center Event Room' ? 'selected' : ''}>Campus Center Event Room</option>
+                    <option value="D-108" ${event.location === 'D-108' ? 'selected' : ''}>D-108</option>
+                    <option value="Esports Lab (Commons Building 80)" ${event.location === 'Esports Lab (Commons Building 80)' ? 'selected' : ''}>Esports Lab</option>
+                    <option value="Lakeside Lodge" ${event.location === 'Lakeside Lodge' ? 'selected' : ''}>Lakeside Lodge</option>
+                    <option value="Online" ${event.location === 'Online' ? 'selected' : ''}>Online</option>
+                </select>`;
+                break;
+            case 'Description':
+                valueEl.outerHTML = `<textarea id="panelEditDescription" class="panel-edit-input"
+                                               rows="3">${event.description || ''}</textarea>`;
+                break;
+        }
+    });
+
+    // Initialize game editable field if not scheduled event
+    if (!event.is_scheduled) {
+        initializeGameTagSelector('edit', event.game);
+    }
+
+    //Attach description character counter
+    attachCharacterCounter('panelEditDescription', 250);
+
+    // Swap edit button for save/cancel
+    const editBtn = document.querySelector('.events-detail-banner-btn:not(.delete)');
+    if (editBtn) {
+        editBtn.outerHTML = `
+            <button class="events-detail-banner-btn panel-save-btn" onclick="submitPanelEdit()" title="Save changes">
+                <i class="fas fa-check"></i>
+            </button>
+            <button class="events-detail-banner-btn panel-cancel-btn" onclick="cancelPanelEdit()" title="Cancel">
+                <i class="fas fa-times"></i>
+            </button>
+        `;
+    }
+}
+
+function cancelPanelEdit() {
+    if (EventState.currentEventId) {
+        openEventDetailPanel(EventState.currentEventId);
+    }
+}
+
+async function submitPanelEdit() {
+    const nameInput = document.getElementById('panelEditName');
+    if (!nameInput?.value?.trim()) {
+        nameInput?.classList.add('panel-edit-input-error');
+        nameInput?.focus();
+        return;
+    }
+    nameInput.classList.remove('panel-edit-input-error');
+
+    const saveBtn = document.querySelector('.panel-save-btn');
+    if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+
+    const locationSelect = document.getElementById('panelEditLocation');
+
+    const formData = {
+        event_id: EventState.currentEventId,
+        event_name: document.getElementById('panelEditName')?.value,
+        event_type: EventState.currentEventData?.event_type,
+        games: document.getElementById('editSelectedGamesInput')?.value ||
+                JSON.stringify(EventState.currentEventData?.game ? [EventState.currentEventData.game] : []),
+        event_date: document.getElementById('panelEditDate')?.value,
+        start_time: document.getElementById('panelEditStartTime')?.value,
+        end_time: document.getElementById('panelEditEndTime')?.value,
+        location: locationSelect?.value,
+        description: document.getElementById('panelEditDescription')?.value,
+        league_id: EventState.currentEventData?.league_id || null
+    };
+
+    try {
+        const response = await fetch('/api/event/edit', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(formData)
+        });
+        const data = await response.json();
+
+        if (data.success) {
+            // Refresh the panel and card with updated data
+            await openEventDetailPanel(EventState.currentEventId);
+            loadEvents();
+        } else {
+            throw new Error(data.message || 'Failed to update event');
+        }
+    } catch (error) {
+        console.error('Error saving event:', error);
+        if (saveBtn) saveBtn.innerHTML = '<i class="fas fa-check"></i>';
+        alert(error.message || 'Failed to save changes.');
+    }
 }
 
 // Update edit/delete buttons based on permissions
@@ -1679,7 +1883,8 @@ function createEditFormFields(event) {
             <div id="editFormMessage" class="form-message" style="display: none;"></div>
 
             <div class="form-actions">
-                <button type="button" class="btn btn-secondary" onclick="cancelEdit()">
+                <button type="button" class="btn btn-secondary"
+                        onclick="document.getElementById('panelEditForm') ? cancelPanelEdit() : cancelEdit()">
                     <i class="fas fa-times"></i> Cancel
                 </button>
                 <button type="button" class="btn btn-primary" onclick="submitEventEdit()">

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -101,6 +101,24 @@ function attachEventListeners() {
     document.querySelectorAll('.filter-box-item--flyout').forEach(trigger => {
     trigger.addEventListener('mouseenter', () => positionFlyout(trigger));
     });
+
+    // Mobile: tap flyout triggers to expand in-place instead of hover
+    if (window.innerWidth <= 768) {
+        document.querySelectorAll('.filter-box-item--flyout').forEach(trigger => {
+            trigger.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const isExpanded = trigger.classList.contains('flyout-expanded');
+                // Collapse all others first
+                document.querySelectorAll('.filter-box-item--flyout.flyout-expanded').forEach(t => {
+                    t.classList.remove('flyout-expanded');
+                });
+                // Toggle this one
+                if (!isExpanded) {
+                    trigger.classList.add('flyout-expanded');
+                }
+            });
+        });
+    }
 }
 
 // ============================================
@@ -144,6 +162,36 @@ function loadEvents() {
         .finally(() => {
             setElementDisplay(elements.loading, 'none');
         });
+
+        // Check if we were redirected here to view a specific event
+        const urlParams = new URLSearchParams(window.location.search);
+        const openEventId = parseInt(urlParams.get('openEvent'));
+        if (openEventId) {
+            window.history.replaceState({}, '', '/dashboard');
+
+            const eventsTab = document.querySelector('[data-tab="events"]');
+            if (eventsTab) eventsTab.click();
+
+            // Pre-fetch event data immediately, in parallel with events loading
+            const eventDataPromise = fetch(`/api/event/${openEventId}`)
+                .then(r => r.json()).catch(() => null);
+            const bannerDataPromise = fetch(`/api/event/${openEventId}/games`)
+                .then(r => r.json()).catch(() => ({ success: false, games: [] }));
+
+            // Open panel exactly once when events container is ready
+            let opened = false;
+            const tryOpen = (attempts = 0) => {
+                if (opened) return;
+                const container = document.getElementById('eventsContainer');
+                if (container && container.style.display !== 'none') {
+                    opened = true;
+                    openEventDetailPanel(openEventId, eventDataPromise, bannerDataPromise);
+                } else if (attempts < 30) {
+                    setTimeout(() => tryOpen(attempts + 1), 150);
+                }
+            };
+            setTimeout(() => tryOpen(), 200);
+        }
 }
 
 // Build different filter options for events
@@ -644,21 +692,28 @@ function handleGameFilterChange() {
 // ============================================
 // FILTER BOX UI
 // ============================================
-
 function toggleFilterBox(panelId) {
     const panel = document.getElementById(panelId);
     const btn = panel?.previousElementSibling;
     const isOpen = panel?.classList.contains('open');
 
-    // Close all open panels first
     document.querySelectorAll('.filter-box-panel.open').forEach(p => {
         p.classList.remove('open');
         p.previousElementSibling?.classList.remove('active');
     });
 
+    const filterBackdrop = document.getElementById('filterBackdrop');
+
     if (!isOpen) {
         panel?.classList.add('open');
         btn?.classList.add('active');
+        if (window.innerWidth <= 768 && filterBackdrop) {
+            filterBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+    } else {
+        filterBackdrop?.classList.remove('open');
+        document.body.style.overflow = '';
     }
 }
 
@@ -728,6 +783,8 @@ function closeAllFilterPanels() {
         p.classList.remove('open');
         p.previousElementSibling?.classList.remove('active');
     });
+    document.getElementById('filterBackdrop')?.classList.remove('open');
+    document.body.style.overflow = '';
 }
 
 // Populate past seasons flyout on hover
@@ -776,8 +833,7 @@ function initGameFlyouts() {
                     flyout.innerHTML = games.map(g => `
                         <div class="filter-box-flyout-item"
                              onclick="${i === 0
-                                ? `applyPrimaryFilterWithSub('game','Game','gameFilter','${g.GameID}','${g.GameTitle.replace(/'/g, "\\'")}')`
-                                : `applySecondaryFilterWithSub('game','Game','gameFilter','${g.GameID}','${g.GameTitle.replace(/'/g, "\\'")}')`
+                                ? `applyPrimaryFilterWithSub('game','Game','gameFilter','${g.GameTitle.replace(/'/g, "\\'")}','${g.GameTitle.replace(/'/g, "\\'")}')` : `applySecondaryFilterWithSub('game','Game','gameFilter','${g.GameTitle.replace(/'/g, "\\'")}','${g.GameTitle.replace(/'/g, "\\'")}')`
                              }">
                             ${g.GameTitle}
                         </div>
@@ -949,6 +1005,7 @@ function renderEvents(events, isAdmin, isGm) {
     }</div>`;
 
     containerDiv.innerHTML = gridHTML;
+    setElementDisplay(containerDiv, 'grid');
 
     // Open detail panel on card click (not the modal)
     containerDiv.querySelectorAll('.event-card').forEach(card => {
@@ -1233,8 +1290,13 @@ function buildEventDetailsHTML(event) {
 }
 
 // Populate the right-hand detail panel when a card is clicked
-async function openEventDetailPanel(eventId) {
+async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetchedBannerData = null) {
     const pane = document.getElementById('eventsDetailPane');
+    if (window.innerWidth <= 768) {
+        pane.classList.add('sheet-open');
+        document.getElementById('sheetBackdrop')?.classList.add('open');
+        document.body.style.overflow = 'hidden';
+    }
     EventState.currentEventId = eventId;
 
     // Show loading state
@@ -1246,7 +1308,9 @@ async function openEventDetailPanel(eventId) {
     `;
 
     try {
-        const response = await fetch(`/api/event/${eventId}`);
+        const response = prefetchedEventData
+            ? { ok: true, json: () => prefetchedEventData }
+            : await fetch(`/api/event/${eventId}`);
         if (!response.ok) throw new Error('Failed to fetch event');
         const event = await response.json();
         EventState.currentEventData = event;
@@ -1277,11 +1341,29 @@ async function openEventDetailPanel(eventId) {
             rows.push(detailRow('info-circle', 'Description', event.description));
         }
 
+        // Fetch banner and event data concurrently
+        const [, bannerData] = await Promise.all([
+            loadNotificationSection(eventId),
+            prefetchedBannerData ||
+                fetch(`/api/event/${eventId}/games`).then(r => r.json()).catch(() => ({ success: false, games: [] }))
+        ]);
+
+        const banners = bannerData.success
+            ? (bannerData.games || []).filter(g => g.GameBanner).map(g => g.GameBanner)
+            : [];
+
+        const bannerHTML = banners.length
+            ? banners.map((url, i) => `
+                <img src="${url}" class="event-detail-banner-img event-detail-banner-slide ${i === 0 ? 'active' : ''}"
+                     alt="Game banner ${i + 1}">
+              `).join('')
+            : '';
+
         pane.innerHTML = `
             <div class="events-detail-panel" data-event-type="${eventTypeClass}">
                 <div class="events-detail-banner-wrapper">
-                    <div class="events-detail-banner" id="eventDetailBanner">
-                        <i class="fas fa-image"></i>&nbsp; No banner available
+                    <div class="events-detail-banner" id="eventDetailBanner" ${!banners.length ? 'style="display:none"' : ''}>
+                        ${bannerHTML}
                     </div>
                     <div class="events-detail-banner-actions">
                         ${canUserEditEvent(event) ? `
@@ -1322,9 +1404,18 @@ async function openEventDetailPanel(eventId) {
             </div>
         `;
 
-        // Reuse the existing notification loader to set subscribe button state
-        await loadNotificationSection(eventId);
-        loadEventBanner(eventId);
+        // Start slideshow if multiple banners
+        if (banners.length > 1) {
+            const bannerEl = document.getElementById('eventDetailBanner');
+            let current = 0;
+            const slides = bannerEl.querySelectorAll('.event-detail-banner-slide');
+            clearInterval(bannerEl._slideInterval);
+            bannerEl._slideInterval = setInterval(() => {
+                slides[current].classList.remove('active');
+                current = (current + 1) % slides.length;
+                slides[current].classList.add('active');
+            }, 3500);
+        }
 
     } catch (error) {
         console.error('Error loading event detail panel:', error);
@@ -1345,13 +1436,19 @@ async function loadEventBanner(eventId) {
         const response = await fetch(`/api/event/${eventId}/games`);
         const data = await response.json();
 
-        if (!data.success || !data.games?.length) return;
+        if (!data.success || !data.games?.length) {
+            bannerEl.style.display = 'none';
+            return;
+        }
 
         const banners = data.games
             .filter(g => g.GameBanner)
             .map(g => g.GameBanner);
 
-        if (!banners.length) return;
+        if (!banners.length) {
+            bannerEl.style.display = 'none';
+            return;
+        }
 
         if (banners.length === 1) {
             bannerEl.innerHTML = `<img src="${banners[0]}" class="event-detail-banner-img" alt="Game banner">`;
@@ -1662,6 +1759,13 @@ function handleEventLoadError(titleElement, content, spinner) {
 
     setElementDisplay(spinner, 'none');
     setElementDisplay(content, 'block');
+}
+
+function closeEventDetailSheet() {
+    const pane = document.getElementById('eventsDetailPane');
+    pane?.classList.remove('sheet-open');
+    document.getElementById('sheetBackdrop')?.classList.remove('open');
+    document.body.style.overflow = '';
 }
 
 // ============================================
@@ -2586,6 +2690,22 @@ function convertTo24Hour(time12h) {
     return `${hours.toString().padStart(2, '0')}:${minutes}`;
 }
 
+function positionFlyout(triggerEl) {
+    const flyout = triggerEl.querySelector('.filter-box-flyout');
+    if (!flyout) return;
+
+    // Reset first so we can measure natural width
+    flyout.classList.remove('flyout-left');
+    flyout.style.display = 'block';
+
+    const rect = flyout.getBoundingClientRect();
+    if (rect.right > window.innerWidth - 8) {
+        flyout.classList.add('flyout-left');
+    }
+
+    flyout.style.display = '';
+}
+
 /* ========================================
    HELPERS
    ======================================== */
@@ -2663,22 +2783,6 @@ function canUserEditEvent(event) {
     return is_admin || is_developer || (is_gm && event.created_by === sessionUserId);
 }
 
-function positionFlyout(triggerEl) {
-    const flyout = triggerEl.querySelector('.filter-box-flyout');
-    if (!flyout) return;
-
-    // Reset first so we can measure natural width
-    flyout.classList.remove('flyout-left');
-    flyout.style.display = 'block';
-
-    const rect = flyout.getBoundingClientRect();
-    if (rect.right > window.innerWidth - 8) {
-        flyout.classList.add('flyout-left');
-    }
-
-    flyout.style.display = '';
-}
-
 // ============================================
 // GLOBAL EXPORTS
 // ============================================
@@ -2708,5 +2812,10 @@ window.handleEditEventTypeChange = handleEditEventTypeChange;
 window.deleteEvent = deleteEvent;
 
 //Filtering with seasons
+window.toggleFilterBox = toggleFilterBox;
 window.handlePastSeasonSelection = handlePastSeasonSelection;
 window.filterEventsByPastSeason = filterEventsByPastSeason;
+
+// Event detail panel opening
+window.openEventDetailPanel = openEventDetailPanel;
+window.closeEventDetailSheet = closeEventDetailSheet;

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -149,7 +149,7 @@ function loadEvents() {
     ])
         .then(([data]) => {
             if (data.success) {
-                EventState.setPermissions(data.is_admin, data.is_developer, data.is_gm);
+                EventState.setPermissions(data.is_admin, data.is_gm, data.is_developer);
                 renderEvents(data.events, data.is_admin, data.is_developer, data.is_gm);
             } else {
                 console.error('Failed to load events:', data.message);
@@ -239,7 +239,7 @@ function loadEventsForPastSeason() {
         .then(response => response.json())
         .then(data => {
             if (data.success) {
-                EventState.setPermissions(data.is_admin, data.is_developer, data.is_gm);
+                EventState.setPermissions(data.is_admin, data.is_gm, data.is_developer);
                 renderEvents(data.events, data.is_admin, data.is_developer, data.is_gm);
 
                 // Update empty state message for season filtering
@@ -1182,6 +1182,7 @@ function toggleFilterBox(panelId) {
     }
 }
 
+// Sets active filter using only a primary option from the first box
 function applyPrimaryFilter(value, label) {
     document.getElementById('filterBox1Label').textContent = label;
     document.getElementById('eventFilter').value = value;
@@ -1196,6 +1197,7 @@ function applyPrimaryFilter(value, label) {
     filterEvents();
 }
 
+// Sets active filter using submenu flyout in first box
 function applyPrimaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
     document.getElementById('filterBox1Label').textContent = `${filterLabel}: ${subLabel}`;
     document.getElementById('eventFilter').value = filterVal;
@@ -1214,6 +1216,7 @@ function applyPrimaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, 
     }
 }
 
+// Sets active filter using the selected past season
 function applyPastSeasonFilter(seasonId, seasonName) {
     document.getElementById('filterBox1Label').textContent = seasonName;
     document.getElementById('eventFilter').value = 'past_season';
@@ -1232,6 +1235,7 @@ function applyPastSeasonFilter(seasonId, seasonName) {
     loadEventsForPastSeason();
 }
 
+// Sets active filter using past season and the primary selection from second filter box
 function applySecondaryFilter(value, label) {
     document.getElementById('filterBox2Label').textContent = label;
     document.getElementById('pastSeasonSecondaryFilter').value = value;
@@ -1241,6 +1245,7 @@ function applySecondaryFilter(value, label) {
     loadEventsForPastSeason();
 }
 
+// Sets active filter using past season and the submenu flyout option selected in the second box
 function applySecondaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
     document.getElementById('filterBox2Label').textContent = `${filterLabel}: ${subLabel}`;
     document.getElementById('pastSeasonSecondaryFilter').value = filterVal;
@@ -1251,13 +1256,20 @@ function applySecondaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal
     loadEventsForPastSeason();
 }
 
+// Closes all filters when options are selected
 function closeAllFilterPanels() {
     document.querySelectorAll('.filter-box-panel.open').forEach(p => {
         p.classList.remove('open');
         p.previousElementSibling?.classList.remove('active');
     });
     document.getElementById('filterBackdrop')?.classList.remove('open');
-    document.body.style.overflow = '';
+
+    // Only restore scroll if no modal or sheet is currently open
+    const anyModalOpen = document.querySelector('.modal[style*="display: block"], .modal[style*="display: flex"]');
+    const sheetOpen = document.getElementById('eventsDetailPane')?.classList.contains('sheet-open');
+    if (!anyModalOpen && !sheetOpen) {
+        document.body.style.overflow = '';
+    }
 }
 
 // Populate past seasons flyout on hover
@@ -1818,7 +1830,7 @@ function canUserDeleteEvent(event) {
             return false;
         }
 
-        return within24Hours; // FIXED: Use within24Hours instead of canDelete
+        return within24Hours;
     }
 
     // Non-GM, non-admin, non-developer users cannot delete

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -92,6 +92,10 @@ function attachEventListeners() {
     if (locationSelect) {
         locationSelect.addEventListener('change', handleLocationChange);
     }
+
+    // Filter box flyouts
+    initPastSeasonsFlyout();
+    initGameFlyouts();
 }
 
 // ============================================
@@ -632,6 +636,164 @@ function handleGameFilterChange() {
     }
 }
 
+// ============================================
+// FILTER BOX UI
+// ============================================
+
+function toggleFilterBox(panelId) {
+    const panel = document.getElementById(panelId);
+    const btn = panel?.previousElementSibling;
+    const isOpen = panel?.classList.contains('open');
+
+    // Close all open panels first
+    document.querySelectorAll('.filter-box-panel.open').forEach(p => {
+        p.classList.remove('open');
+        p.previousElementSibling?.classList.remove('active');
+    });
+
+    if (!isOpen) {
+        panel?.classList.add('open');
+        btn?.classList.add('active');
+    }
+}
+
+function applyPrimaryFilter(value, label) {
+    document.getElementById('filterBox1Label').textContent = label;
+    document.getElementById('eventFilter').value = value;
+    closeAllFilterPanels();
+
+    // Hide Box 2 and reset season state
+    document.getElementById('filterBox2').style.display = 'none';
+    PastSeasonFilterState.selectedSeasonId = null;
+    PastSeasonFilterState.isFilteringPastSeason = false;
+
+    filterEvents();
+}
+
+function applyPrimaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
+    document.getElementById('filterBox1Label').textContent = `${filterLabel}: ${subLabel}`;
+    document.getElementById('eventFilter').value = filterVal;
+    document.getElementById(subSelectId).value = subVal;
+    closeAllFilterPanels();
+
+    document.getElementById('filterBox2').style.display = 'none';
+    PastSeasonFilterState.selectedSeasonId = null;
+    PastSeasonFilterState.isFilteringPastSeason = false;
+
+    handleTypeFilterChange();
+}
+
+function applyPastSeasonFilter(seasonId, seasonName) {
+    document.getElementById('filterBox1Label').textContent = seasonName;
+    document.getElementById('eventFilter').value = 'past_season';
+    document.getElementById('pastSeasonSelect').value = seasonId;
+    closeAllFilterPanels();
+
+    PastSeasonFilterState.isFilteringPastSeason = true;
+    PastSeasonFilterState.selectedSeasonId = seasonId;
+    PastSeasonFilterState.selectedSeasonName = seasonName;
+    PastSeasonFilterState.secondaryFilter = 'all';
+
+    // Show Box 2 with reset label
+    document.getElementById('filterBox2Label').textContent = 'All Events';
+    document.getElementById('filterBox2').style.display = 'block';
+
+    loadEventsForPastSeason();
+}
+
+function applySecondaryFilter(value, label) {
+    document.getElementById('filterBox2Label').textContent = label;
+    document.getElementById('pastSeasonSecondaryFilter').value = value;
+    closeAllFilterPanels();
+    PastSeasonFilterState.secondaryFilter = value;
+    loadEventsForPastSeason();
+}
+
+function applySecondaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, subLabel) {
+    document.getElementById('filterBox2Label').textContent = `${filterLabel}: ${subLabel}`;
+    document.getElementById('pastSeasonSecondaryFilter').value = filterVal;
+    document.getElementById(subSelectId).value = subVal;
+    PastSeasonFilterState.secondaryFilter = filterVal;
+    closeAllFilterPanels();
+    loadEventsForPastSeason();
+}
+
+function closeAllFilterPanels() {
+    document.querySelectorAll('.filter-box-panel.open').forEach(p => {
+        p.classList.remove('open');
+        p.previousElementSibling?.classList.remove('active');
+    });
+}
+
+// Populate past seasons flyout on hover
+function initPastSeasonsFlyout() {
+    const trigger = document.getElementById('pastSeasonsFlyoutTrigger');
+    const flyout = document.getElementById('pastSeasonsFlyout');
+    if (!trigger || !flyout) return;
+
+    let loaded = false;
+    trigger.addEventListener('mouseenter', async () => {
+        if (loaded) return;
+        loaded = true;
+        try {
+            const response = await fetch('/api/seasons/past');
+            const data = await response.json();
+            if (data.success && data.seasons?.length) {
+                flyout.innerHTML = data.seasons.map(s => `
+                    <div class="filter-box-flyout-item"
+                         onclick="applyPastSeasonFilter('${s.season_id}', '${s.season_name.replace(/'/g, "\\'")}')">
+                        ${s.season_name}
+                    </div>
+                `).join('');
+            } else {
+                flyout.innerHTML = '<div class="filter-box-flyout-loading">No past seasons</div>';
+            }
+        } catch {
+            flyout.innerHTML = '<div class="filter-box-flyout-loading">Failed to load</div>';
+        }
+    });
+}
+
+// Populate game flyouts on hover (both Box 1 and Box 2)
+function initGameFlyouts() {
+    ['gameFilterFlyoutTrigger1', 'gameFilterFlyoutTrigger2'].forEach((triggerId, i) => {
+        const trigger = document.getElementById(triggerId);
+        const flyout = document.getElementById(`gameFilterFlyout${i + 1}`);
+        if (!trigger || !flyout) return;
+
+        let loaded = false;
+        trigger.addEventListener('mouseenter', async () => {
+            if (loaded) return;
+            loaded = true;
+            try {
+                const games = await loadGamesList();
+                if (games?.length) {
+                    flyout.innerHTML = games.map(g => `
+                        <div class="filter-box-flyout-item"
+                             onclick="${i === 0
+                                ? `applyPrimaryFilterWithSub('game','Game','gameFilter','${g.GameID}','${g.GameTitle.replace(/'/g, "\\'")}')`
+                                : `applySecondaryFilterWithSub('game','Game','gameFilter','${g.GameID}','${g.GameTitle.replace(/'/g, "\\'")}')`
+                             }">
+                            ${g.GameTitle}
+                        </div>
+                    `).join('');
+                } else {
+                    flyout.innerHTML = '<div class="filter-box-flyout-loading">No games found</div>';
+                }
+            } catch {
+                flyout.innerHTML = '<div class="filter-box-flyout-loading">Failed to load</div>';
+            }
+        });
+    });
+}
+
+// Close panels when clicking outside
+document.addEventListener('click', (e) => {
+    if (!e.target.closest('.filter-box')) {
+        closeAllFilterPanels();
+    }
+});
+
 // Load events for selected past season with filters
 function loadEventsForPastSeason() {
     if (!PastSeasonFilterState.selectedSeasonId) {
@@ -1113,8 +1275,8 @@ async function openEventDetailPanel(eventId) {
         pane.innerHTML = `
             <div class="events-detail-panel" data-event-type="${eventTypeClass}">
                 <div class="events-detail-banner-wrapper">
-                    <div class="events-detail-banner">
-                        <i class="fas fa-image"></i>&nbsp; Banner coming soon
+                    <div class="events-detail-banner" id="eventDetailBanner">
+                        <i class="fas fa-image"></i>&nbsp; No banner available
                     </div>
                     <div class="events-detail-banner-actions">
                         ${canUserEditEvent(event) ? `
@@ -1157,6 +1319,7 @@ async function openEventDetailPanel(eventId) {
 
         // Reuse the existing notification loader to set subscribe button state
         await loadNotificationSection(eventId);
+        loadEventBanner(eventId);
 
     } catch (error) {
         console.error('Error loading event detail panel:', error);
@@ -1166,6 +1329,46 @@ async function openEventDetailPanel(eventId) {
                 <p>Failed to load event details.</p>
             </div>
         `;
+    }
+}
+
+async function loadEventBanner(eventId) {
+    const bannerEl = document.getElementById('eventDetailBanner');
+    if (!bannerEl) return;
+
+    try {
+        const response = await fetch(`/api/event/${eventId}/games`);
+        const data = await response.json();
+
+        if (!data.success || !data.games?.length) return;
+
+        const banners = data.games
+            .filter(g => g.GameBanner)
+            .map(g => g.GameBanner);
+
+        if (!banners.length) return;
+
+        if (banners.length === 1) {
+            bannerEl.innerHTML = `<img src="${banners[0]}" class="event-detail-banner-img" alt="Game banner">`;
+            return;
+        }
+
+        bannerEl.innerHTML = banners.map((url, i) => `
+            <img src="${url}" class="event-detail-banner-img event-detail-banner-slide ${i === 0 ? 'active' : ''}"
+                 alt="Game banner ${i + 1}">
+        `).join('');
+
+        let current = 0;
+        const slides = bannerEl.querySelectorAll('.event-detail-banner-slide');
+        clearInterval(bannerEl._slideInterval);
+        bannerEl._slideInterval = setInterval(() => {
+            slides[current].classList.remove('active');
+            current = (current + 1) % slides.length;
+            slides[current].classList.add('active');
+        }, 3500);
+
+    } catch (err) {
+        console.error('Error loading event banner:', err);
     }
 }
 

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -62,7 +62,6 @@ const EventState = {
 function initializeEventsModule(eventsDataFromServer) {
     EventState.eventsData = eventsDataFromServer || {};
     attachEventListeners();
-    console.log('Events module initialized');
 }
 
 // Event listener for easier management
@@ -214,7 +213,7 @@ function buildEventFilterParams() {
 
     // Add game filter if applicable
     if (filterValue === 'game') {
-        const gameFilter = document.getElementById('gameFilter')?.value;
+        const gameFilter = EventState.selectedGame;
         if (gameFilter) params += `&game=${encodeURIComponent(gameFilter)}`;
     }
 
@@ -582,14 +581,14 @@ function filterEvents() {
         return;
     }
 
-    updateFilterColumnsCount();
+
 
     // Load events with main filter (defaults to current active season on backend)
     loadEvents();
 }
 
 /* ================================
-    SEASON FILTERING STUFF
+    SEASON FILTERING
    ================================ */
 
 // Handle past season selection
@@ -622,7 +621,7 @@ function handlePastSeasonSelection() {
     // Load events for this past season
     loadEventsForPastSeason();
 
-    updateFilterColumnsCount();
+
 }
 
 // Filter events by past season and secondary filter
@@ -652,7 +651,7 @@ function filterEventsByPastSeason() {
     // Load events with secondary filter
     loadEventsForPastSeason();
 
-    updateFilterColumnsCount();
+
 }
 
 // Filter by past season and type
@@ -720,6 +719,7 @@ function toggleFilterBox(panelId) {
 function applyPrimaryFilter(value, label) {
     document.getElementById('filterBox1Label').textContent = label;
     document.getElementById('eventFilter').value = value;
+    EventState.selectedGame = null;
     closeAllFilterPanels();
 
     // Hide Box 2 and reset season state
@@ -734,13 +734,18 @@ function applyPrimaryFilterWithSub(filterVal, filterLabel, subSelectId, subVal, 
     document.getElementById('filterBox1Label').textContent = `${filterLabel}: ${subLabel}`;
     document.getElementById('eventFilter').value = filterVal;
     document.getElementById(subSelectId).value = subVal;
+    if (filterVal === 'game') EventState.selectedGame = subVal;
     closeAllFilterPanels();
 
     document.getElementById('filterBox2').style.display = 'none';
     PastSeasonFilterState.selectedSeasonId = null;
     PastSeasonFilterState.isFilteringPastSeason = false;
 
-    handleTypeFilterChange();
+    if (filterVal === 'game') {
+        filterEventsByGame();
+    } else {
+        handleTypeFilterChange();
+    }
 }
 
 function applyPastSeasonFilter(seasonId, seasonName) {
@@ -964,31 +969,14 @@ function filterEventsByType() {
 // Filter events by game (called when game dropdown changes)
 function filterEventsByGame() {
     const gameFilterSelect = document.getElementById('gameFilter');
-    if (gameFilterSelect?.value) {
+    if (gameFilterSelect?.value || EventState.selectedGame) {
         loadEvents();
     }
-}
-
-/**
- * Update the number of visible filter columns
- * Adds data-columns attribute for CSS styling
- */
-function updateFilterColumnsCount() {
-    const filterContainer = document.querySelector('.event-filters-container');
-    if (!filterContainer) return;
-
-    // Count visible filter dropdowns
-    const visibleFilters = filterContainer.querySelectorAll('.event-filter-dropdown:not([style*="display: none"])');
-    const columnCount = visibleFilters.length > 1 ? '2' : '1';
-
-    filterContainer.setAttribute('data-columns', columnCount);
 }
 
 // ============================================
 // EVENT RENDERING
 // ============================================
-
-// Render events in the grid
 function renderEvents(events, isAdmin, isGm) {
     const containerDiv = document.getElementById('eventsContainer');
     const emptyStateDiv = document.getElementById('eventsEmptyState');
@@ -1055,19 +1043,6 @@ function createEventCard(event, isAdmin, isGm) {
                 <span class="event-card-date"><i class="fas fa-calendar"></i>${event.date}</span>
                 ${timeDisplay ? `<span class="event-card-time">${timeDisplay}</span>` : ''}
             </div>
-        </div>
-    `;
-}
-
-// Create a detail row for event card
-function createEventDetailRow(icon, label, value) {
-    return `
-        <div class="event-detail-row">
-            <div class="event-detail-icon">
-                <i class="fas fa-${icon}"></i>
-            </div>
-            <span class="event-detail-label">${label}:</span>
-            <span class="event-detail-value">${value}</span>
         </div>
     `;
 }
@@ -1178,117 +1153,6 @@ function showEventsError() {
     setElementDisplay(containerDiv, 'block');
 }
 
-// ============================================
-// EVENT DETAILS MODAL - VIEW & MANAGEMENT
-// ============================================
-
-/**
- * Open event details modal
- * @param {number} eventId - ID of event to display
- */
-async function openEventModal(eventId, source = 'events') {
-    const modal = document.getElementById('eventDetailsModal');
-    const spinner = document.getElementById('eventLoadingSpinner');
-    const content = document.getElementById('eventDetailsContent');
-    const deleteBtn = document.getElementById('deleteEventBtn');
-    const titleElement = document.getElementById('eventModalTitle');
-
-    EventState.currentEventId = eventId;
-    EventState.deletionSource = source;
-
-    // Set initial loading state
-    if (titleElement) titleElement.textContent = 'Loading...';
-    setModalLoadingState(modal, spinner, content, deleteBtn, true);
-
-    try {
-        // Fetch event details
-        const response = await fetch(`/api/event/${eventId}`);
-        if (!response.ok) throw new Error('Failed to fetch event details');
-
-        const event = await response.json();
-        EventState.currentEventData = event;
-
-        // Add event type for styling
-        const eventTypeClass = (event.event_type || 'event').toLowerCase();
-        modal.setAttribute('data-event-type', eventTypeClass);
-
-        // Update modal content
-        if (titleElement) titleElement.textContent = event.name || 'Event Details';
-        content.innerHTML = buildEventDetailsHTML(event);
-
-        // Show content and update buttons
-        setModalLoadingState(modal, spinner, content, deleteBtn, false);
-        updateEventModalButtons(event);
-
-        // Load notification section
-        await loadNotificationSection(eventId);
-
-    } catch (error) {
-        console.error('Error loading event details:', error);
-        handleEventLoadError(titleElement, content, spinner);
-    }
-}
-
-// Set modal loading state
-function setModalLoadingState(modal, spinner, content, deleteBtn, isLoading) {
-    modal.style.display = 'block';
-    setElementDisplay(spinner, isLoading ? 'block' : 'none');
-    setElementDisplay(content, isLoading ? 'none' : 'block');
-    setElementDisplay(deleteBtn, isLoading ? 'none' : 'flex');
-    document.body.style.overflow = 'hidden';
-}
-
-// Build event details HTML
-function buildEventDetailsHTML(event) {
-    const sections = [];
-
-    // Date section
-    sections.push(createDetailSection('calendar-alt', 'Date', event.date));
-
-    // Time section (if exists)
-    if (event.start_time) {
-        const timeStr = `${event.start_time}${event.end_time ? ' - ' + event.end_time : ''}`;
-        sections.push(createDetailSection('clock', 'Time', timeStr));
-    }
-
-    // Event Type section
-    if (event.event_type) {
-        sections.push(createDetailSection('tag', 'Event Type', event.event_type));
-    }
-
-    // Game section
-    if (event.game) {
-        sections.push(createDetailSection('gamepad', 'Game', event.game));
-    }
-     // League section (only for Match events)
-    if (event.event_type === 'Match' && event.league_name) {
-        sections.push(createDetailSection('trophy', 'League', event.league_name, true));
-    }
-
-    // Location section (full width)
-    if (event.location) {
-        sections.push(createDetailSection('map-marker-alt', 'Location', event.location, true));
-    }
-
-    // Description section (full width)
-    sections.push(`
-        <div class="event-detail-section full-width">
-            <div style="display: flex; gap: 0.75rem;">
-                <div class="event-detail-icon"><i class="fas fa-info-circle"></i></div>
-                <div class="event-detail-content">
-                    <h3>Description</h3>
-                    <p>${event.description}</p>
-                </div>
-            </div>
-        </div>
-    `);
-
-    // Notification section (full width)
-    sections.push(createNotificationSection());
-
-    return `<div class="event-detail-grid">${sections.join('')}</div>`;
-}
-
 // Populate the right-hand detail panel when a card is clicked
 async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetchedBannerData = null) {
     const pane = document.getElementById('eventsDetailPane');
@@ -1342,8 +1206,7 @@ async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetc
         }
 
         // Fetch banner and event data concurrently
-        const [, bannerData] = await Promise.all([
-            loadNotificationSection(eventId),
+        const [bannerData] = await Promise.all([
             prefetchedBannerData ||
                 fetch(`/api/event/${eventId}/games`).then(r => r.json()).catch(() => ({ success: false, games: [] }))
         ]);
@@ -1404,6 +1267,14 @@ async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetc
             </div>
         `;
 
+        // Re-apply scroll lock on mobile after innerHTML replacement
+        if (window.innerWidth <= 768) {
+            document.body.style.overflow = 'hidden';
+        }
+
+        // Now load the notification section
+        await loadNotificationSection(eventId);
+
         // Start slideshow if multiple banners
         if (banners.length > 1) {
             const bannerEl = document.getElementById('eventDetailBanner');
@@ -1428,6 +1299,7 @@ async function openEventDetailPanel(eventId, prefetchedEventData = null, prefetc
     }
 }
 
+// Load banners to display with event detail panel
 async function loadEventBanner(eventId) {
     const bannerEl = document.getElementById('eventDetailBanner');
     if (!bannerEl) return;
@@ -1487,42 +1359,7 @@ function detailRow(icon, label, value) {
     `;
 }
 
-// Create a detail section for event modal
-function createDetailSection(icon, title, content, fullWidth = false) {
-    const style = fullWidth ? ' style="grid-column: 1 / -1;"' : '';
-    return `
-        <div class="event-detail-section"${style}>
-            <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
-            <div class="event-detail-content">
-                <h3>${title}</h3>
-                <p>${content}</p>
-            </div>
-        </div>
-    `;
-}
-
-// Create notification section HTML
-function createNotificationSection() {
-    return `
-        <div class="event-notification-section full-width"
-             id="eventNotificationSection"
-             style="grid-column: 1 / -1;">
-            <div class="notification-opt-in" style="width: 100%; display: flex; justify-content: center;">
-                <div class="notification-icon">
-                    <i class="fas fa-bell" style="font-size: 1.5rem;"></i>
-                </div>
-                <div class="notification-text">
-                    <div class="title">Event Reminders</div>
-                    <div class="subtitle">Get notified about this event</div>
-                </div>
-                <button class="notification-btn" id="notificationBtn" onclick="toggleEventSubscription()">
-                    <span id="notificationBtnText">Loading...</span>
-                </button>
-            </div>
-        </div>
-    `;
-}
-
+// Enables and disables event detail panel editing
 function togglePanelEditMode() {
     const event = EventState.currentEventData;
     if (!event) return;
@@ -1657,12 +1494,14 @@ function togglePanelEditMode() {
     }
 }
 
+// Cancel editing in the event detail panel
 function cancelPanelEdit() {
     if (EventState.currentEventId) {
         openEventDetailPanel(EventState.currentEventId);
     }
 }
 
+// Confirms edits made in the event detail panel
 async function submitPanelEdit() {
     const nameInput = document.getElementById('panelEditName');
     if (!nameInput?.value?.trim()) {
@@ -1713,36 +1552,6 @@ async function submitPanelEdit() {
     }
 }
 
-// Update edit/delete buttons based on permissions
-function updateEventModalButtons(event) {
-    const editBtn = document.getElementById("editEventBtn");
-    const deleteBtn = document.getElementById("deleteEventBtn");
-
-    // Show edit button if user can edit
-    if (editBtn && canUserEditEvent(event)) {
-        editBtn.style.display = 'flex';
-    } else {
-        if (editBtn) editBtn.style.display = 'none';
-    }
-
-    // Show delete button if user can delete
-    if (deleteBtn) {
-        const canDelete = canUserDeleteEvent(event);
-
-        if (canDelete) {
-            // Simple trash icon only
-            deleteBtn.innerHTML = '<i class="fas fa-trash"></i>';
-            deleteBtn.title = 'Delete event';
-
-            deleteBtn.style.display = 'flex';
-        } else {
-            deleteBtn.style.display = 'none';
-        }
-    } else {
-        console.error('Delete button element not found!');
-    }
-}
-
 // Handle event load error
 function handleEventLoadError(titleElement, content, spinner) {
     if (titleElement) {
@@ -1761,6 +1570,7 @@ function handleEventLoadError(titleElement, content, spinner) {
     setElementDisplay(content, 'block');
 }
 
+// Closes the event detail pane in mobile view
 function closeEventDetailSheet() {
     const pane = document.getElementById('eventsDetailPane');
     pane?.classList.remove('sheet-open');
@@ -1771,8 +1581,6 @@ function closeEventDetailSheet() {
 // ============================================
 // CREATE EVENT MODAL
 // ============================================
-
-// Open create event modal
 function openCreateEventModal() {
     const modal = document.getElementById('createEventModal');
     const form = document.getElementById('createEventForm');
@@ -1960,8 +1768,6 @@ async function handleCreateEventSubmit(e) {
 // ============================================
 // DAY MODAL (CALENDAR VIEW)
 // ============================================
-
-// Open day events modal
 function openDayModal(date, dateTitle) {
     const modal = document.getElementById('dayEventsModal');
     const modalTitle = document.getElementById('modalDayTitle');
@@ -2017,497 +1823,8 @@ function closeDayModal() {
 }
 
 // ============================================
-// EDIT EVENT MODAL
-// ============================================
-
-// Toggle edit mode
-function toggleEditMode() {
-    const content = document.getElementById('eventDetailsContent');
-    const editForm = document.getElementById('eventEditForm');
-    const editBtn = document.getElementById('editEventBtn');
-    const deleteBtn = document.getElementById('deleteEventBtn');
-    const titleElement = document.getElementById('eventModalTitle');
-
-    // Hide view mode, show edit mode
-    setElementDisplay(content, 'none');
-    setElementDisplay(editForm, 'block');
-    setElementDisplay(editBtn, 'none');
-    setElementDisplay(deleteBtn, 'none');
-
-    if (titleElement) {
-        titleElement.textContent = 'Edit Event';
-    }
-
-    createEditForm();
-}
-
-// Create edit form with pre-populated data
-function createEditForm() {
-    const editForm = document.getElementById('eventEditForm');
-    if (!EventState.currentEventData) return;
-
-    const event = EventState.currentEventData;
-
-    // Set the HTML
-    editForm.innerHTML = createEditFormFields(event);
-
-    // Initialize game tag selector
-    initializeGameTagSelector('edit', event.game);
-    
-    // Setup location dropdown
-    setupEditLocationDropdown(event.location);
-
-    // Character Counter
-    attachCharacterCounter('editDescription', 250);
-
-    
-    // **MOVED: Wait for DOM to be ready before calling these functions**
-    setTimeout(() => {
-        // Handle event type (will show/hide league field)
-        handleEditEventTypeChange();
-        
-
-    }, 50); // Small delay to ensure DOM is ready
-}
-
-// Create edit form fields
-function createEditFormFields(event) {
-    const escapedDescription = (event.description || '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-
-    return `
-        <form id="editEventFormData" class="event-form-modal">
-            <div class="form-group">
-                <label for="editEventName">Event Name *</label>
-                <input type="text" 
-                       id="editEventName" 
-                       name="eventName" 
-                       value="${event.name || ''}" 
-                       required>
-            </div>
-
-            <div class="form-group">
-                <label for="editEventType">Event Type *</label>
-                <select id="editEventType" name="eventType" required onchange="handleEditEventTypeChange()">
-                    <option value="Event" ${event.event_type === 'Event' ? 'selected' : ''}>Event</option>
-                    <option value="Tournament" ${event.event_type === 'Tournament' ? 'selected' : ''}>Tournament</option>
-                    <option value="Misc" ${event.event_type === 'Misc' ? 'selected' : ''}>Misc</option>
-                </select>
-            </div>
-
-            <!-- League Field (SINGLE INSTANCE - only shown for Match events) -->
-            <div class="form-group" id="editEventLeagueFieldGroup" style="display: ${event.event_type === 'Match' ? 'flex' : 'none'};">
-                <label for="editEventLeagueDropdown">League ${event.event_type === 'Match' ? '*' : '(Optional)'}</label>
-                <select id="editEventLeagueDropdown" 
-                        name="league_id" 
-                        class="game-dropdown-single" 
-                        ${event.event_type === 'Match' ? 'required' : ''}>
-                    <option value="">Select league</option>
-                </select>
-                <div id="editEventLeagueLoadingIndicator" style="display: none; margin-top: 0.5rem; color: var(--text-secondary); font-size: 0.875rem;">
-                    <i class="fas fa-spinner fa-spin"></i> Loading leagues...
-                </div>
-            </div>
-
-            <!-- Games Field -->
-            <div class="form-group" id="editGameFieldGroup">
-                <label for="editGameDropdown">Games (Optional)</label>
-                <div style="color: var(--text-secondary); font-size: 0.8125rem; margin-bottom: 0.5rem;">
-                    Select games from the dropdown - they'll appear as tags below
-                </div>
-
-                <div id="editSelectedGamesContainer" class="selected-games-container"></div>
-
-                <select id="editGameDropdown" class="game-dropdown-single">
-                    <option value="">+ Add a game</option>
-                </select>
-
-                <div id="editGameLoadingIndicator" style="display: none; margin-top: 0.5rem; color: var(--text-secondary); font-size: 0.875rem;">
-                    <i class="fas fa-spinner fa-spin"></i> Loading games...
-                </div>
-
-                <input type="hidden" id="editSelectedGamesInput" name="games" value="[]">
-            </div>
-
-            <div class="form-group">
-                <label for="editDate">Date *</label>
-                <input type="date" 
-                       id="editDate" 
-                       name="eventDate" 
-                       value="${event.date_raw || ''}" 
-                       required>
-            </div>
-
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="editStartTime">Start Time *</label>
-                    <input type="time" 
-                           id="editStartTime" 
-                           name="startTime"
-                           value="${convertTo24Hour(event.start_time)}" 
-                           required>
-                </div>
-                <div class="form-group">
-                    <label for="editEndTime">End Time *</label>
-                    <input type="time" 
-                           id="editEndTime" 
-                           name="endTime"
-                           value="${convertTo24Hour(event.end_time)}" 
-                           required>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label for="editLocation">Location *</label>
-                <select id="editLocation" name="eventLocation" required>
-                    <option value="">Select location</option>
-                    <option value="Campus Center">Campus Center</option>
-                    <option value="Campus Center Coffee House">Campus Center Coffee House</option>
-                    <option value="Campus Center Event Room">Campus Center Event Room</option>
-                    <option value="D-108">D-108</option>
-                    <option value="Esports Lab (Commons Building 80)">Esports Lab (Commons Building 80)</option>
-                    <option value="Lakeside Lodge">Lakeside Lodge</option>
-                    <option value="Online">Online</option>
-                    <option value="other">Other</option>
-                </select>
-            </div>
-
-            <div class="form-group" id="editCustomLocationGroup" style="display: none;">
-                <label for="editCustomLocation">Custom Location</label>
-                <input type="text" 
-                       id="editCustomLocation" 
-                       name="customLocation" 
-                       placeholder="Enter custom location">
-            </div>
-
-            <div class="form-group">
-                <label for="editDescription">Description *</label>
-                <textarea id="editDescription" 
-                          name="eventDescription" 
-                          rows="4"
-                          required>${escapedDescription}</textarea>
-            </div>
-
-            <div id="editFormMessage" class="form-message" style="display: none;"></div>
-
-            <div class="form-actions">
-                <button type="button" class="btn btn-secondary"
-                        onclick="document.getElementById('panelEditForm') ? cancelPanelEdit() : cancelEdit()">
-                    <i class="fas fa-times"></i> Cancel
-                </button>
-                <button type="button" class="btn btn-primary" onclick="submitEventEdit()">
-                    <i class="fas fa-save"></i> Save Changes
-                </button>
-            </div>
-        </form>
-    `;
-}
-
-// Create event type options
-function createEventTypeOptions(selectedType) {
-    const types = ['Event', 'Match', 'Practice', 'Tournament', 'Misc'];
-    return types.map(type =>
-        `<option value="${type}" ${selectedType === type ? 'selected' : ''}>${type}</option>`
-    ).join('');
-}
-
-// Create game tag field
-function createGameTagField(context) {
-    const prefix = context === 'edit' ? 'edit' : '';
-    const idPrefix = prefix ? `${prefix}` : '';
-    const capitalPrefix = prefix.charAt(0).toUpperCase() + prefix.slice(1);
-
-    return `
-        <div class="form-group" id="${idPrefix}GameFieldGroup">
-            <label for="${idPrefix}GameDropdown">Games (Optional)</label>
-            <div style="color: var(--text-secondary); font-size: 0.8125rem; margin-bottom: 0.5rem;">
-                Select games from the dropdown - they'll appear as tags below
-            </div>
-
-            <div id="${idPrefix}SelectedGamesContainer" class="selected-games-container"></div>
-
-            <select id="${idPrefix}GameDropdown" class="game-dropdown-single">
-                <option value="">+ Add a game</option>
-            </select>
-
-            <div id="${idPrefix}GameLoadingIndicator" style="display: none; margin-top: 0.5rem; color: var(--text-secondary); font-size: 0.875rem;">
-                <i class="fas fa-spinner fa-spin"></i> Loading games...
-            </div>
-
-            <input type="hidden" id="${idPrefix}SelectedGamesInput" name="games" value="[]">
-        </div>
-    `;
-}
-
-// Create time input fields
-function createTimeFields(event) {
-    return `
-        <div class="form-row" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
-            <div class="form-group" style="margin: 0;">
-                <label for="editStartTime">Start Time</label>
-                <input type="time" id="editStartTime" name="startTime"
-                       value="${convertTo24Hour(event.start_time)}" required>
-            </div>
-            <div class="form-group" style="margin: 0;">
-                <label for="editEndTime">End Time</label>
-                <input type="time" id="editEndTime" name="endTime"
-                       value="${convertTo24Hour(event.end_time)}" required>
-            </div>
-        </div>
-    `;
-}
-
-// Create location fields
-function createLocationFields(context, currentLocation = '') {
-    const prefix = context === 'edit' ? 'edit' : '';
-    const idPrefix = prefix ? `${prefix}` : '';
-
-    return `
-        <div class="form-group">
-            <label for="${idPrefix}Location">Location</label>
-            <select id="${idPrefix}Location" name="eventLocation" required>
-                <option value="">Select location</option>
-                <option value="Campus Center">Campus Center</option>
-                <option value="Campus Center Coffee House">Campus Center Coffee House</option>
-                <option value="Campus Center Event Room">Campus Center Event Room</option>
-                <option value="D-108">D-108</option>
-                <option value="Esports Lab (Commons Building 80)">Esports Lab (Commons Building 80)</option>
-                <option value="Lakeside Lodge">Lakeside Lodge</option>
-                <option value="Online">Online</option>
-                <option value="other">Other</option>
-            </select>
-        </div>
-
-        <div class="form-group" id="${idPrefix}CustomLocationGroup" style="display: none;">
-            <label for="${idPrefix}CustomLocation">Custom Location</label>
-            <input type="text" id="${idPrefix}CustomLocation" name="customLocation" placeholder="Enter custom location">
-        </div>
-    `;
-}
-
-// Create form action buttons
-function createFormActionButtons() {
-    return `
-        <div class="form-actions">
-            <button type="button" class="btn btn-secondary" onclick="cancelEdit()">
-                <i class="fas fa-times"></i> Cancel
-            </button>
-            <button type="button" class="btn btn-primary" onclick="submitEventEdit()">
-                <i class="fas fa-save"></i> Save Changes
-            </button>
-        </div>
-    `;
-}
-
-// Setup edit location dropdown with current value
-function setupEditLocationDropdown(currentLocation) {
-    const presetLocations = [
-        'Campus Center',
-        'Campus Center Coffee House',
-        'Campus Center Event Room',
-        'D-108',
-        'Esports Lab (Commons Building 80)',
-        'Lakeside Lodge',
-        'Online'
-    ];
-
-    const locationSelect = document.getElementById('editLocation');
-    const customLocationGroup = document.getElementById('editCustomLocationGroup');
-    const customLocationInput = document.getElementById('editCustomLocation');
-
-    if (!locationSelect) return;
-
-    // Set current value
-    if (presetLocations.includes(currentLocation)) {
-        locationSelect.value = currentLocation;
-    } else {
-        locationSelect.value = 'other';
-        setElementDisplay(customLocationGroup, 'block');
-        customLocationInput.value = currentLocation;
-        customLocationInput.required = true;
-    }
-
-    // Add change listener
-    locationSelect.addEventListener('change', function() {
-        if (this.value === 'other') {
-            setElementDisplay(customLocationGroup, 'block');
-            customLocationInput.required = true;
-        } else {
-            setElementDisplay(customLocationGroup, 'none');
-            customLocationInput.required = false;
-            customLocationInput.value = '';
-        }
-    });
-}
-
-// Handle event type change in edit form
-function handleEditEventTypeChange() {
-    const eventType = document.getElementById('editEventType')?.value;
-    const gameFieldGroup = document.getElementById('editGameFieldGroup');
-    const leagueGroup = document.getElementById('editEventLeagueFieldGroup');
-    const leagueDropdown = document.getElementById('editEventLeagueDropdown');
-
-    // Only proceed if we have the event type
-    if (!eventType) {
-        console.warn('handleEditEventTypeChange: editEventType not found');
-        return;
-    }
-
-    // Handle game field visibility
-    if (eventType === 'Misc') {
-        if (gameFieldGroup) {
-            setElementDisplay(gameFieldGroup, 'none');
-            clearSelectedGames('edit');
-        }
-    } else {
-        if (gameFieldGroup) {
-            setElementDisplay(gameFieldGroup, 'block');
-        }
-    }
-    
-    // Handle league field visibility
-    if (!leagueGroup || !leagueDropdown) {
-        console.warn('handleEditEventTypeChange: League elements not found');
-        return;
-    }
-    
-    const isMatch = eventType === 'Match';
-    
-    // Show/hide league field
-    leagueGroup.style.display = isMatch ? 'flex' : 'none';
-    
-    // Update required attribute
-    if (isMatch) {
-        leagueDropdown.setAttribute('required', 'required');
-        
-        // Update label to show required
-        const label = leagueGroup.querySelector('label');
-        if (label && !label.innerHTML.includes('*')) {
-            label.innerHTML = 'League <span style="color: #ff5252;">*</span>';
-        }
-        
-
-    } else {
-        leagueDropdown.removeAttribute('required');
-        leagueDropdown.value = '';
-        
-        // Update label to show optional
-        const label = leagueGroup.querySelector('label');
-        if (label) {
-            label.textContent = 'League (Optional)';
-        }
-    }
-}
-
-
-// Submit edit event
-async function submitEventEdit() {
-    const formMessage = document.getElementById('editFormMessage');
-    const submitBtn = document.querySelector('#editEventFormData .btn-primary');
-
-    if (!submitBtn) return;
-
-    const eventType = document.getElementById('editEventType')?.value;
-    const leagueDropdown = document.getElementById('editEventLeagueDropdown');
-    
-    if (eventType === 'Match' && (!leagueDropdown?.value)) {
-        formMessage.textContent = 'Please select a league for Match events.';
-        formMessage.className = 'form-message error';
-        formMessage.style.display = 'block';
-        leagueDropdown?.focus();
-        return;
-    }
-
-    // Set loading state
-    submitBtn.disabled = true;
-    submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
-
-    // Gather form data
-    const formData = gatherEditFormData();
-
-    try {
-        const response = await fetch('/api/event/edit', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(formData)
-        });
-
-        const data = await response.json();
-
-        if (data.success) {
-            // Direct manipulation
-            formMessage.textContent = data.message;
-            formMessage.className = 'form-message success';
-            formMessage.style.display = 'block';
-
-            setTimeout(() => {
-                window.location.reload();
-            }, 350);
-        } else {
-            throw new Error(data.message || 'Failed to update event');
-        }
-    } catch (error) {
-        console.error('Error updating event:', error);
-
-        // Direct manipulation for error
-        formMessage.textContent = error.message || 'An error occurred while updating the event';
-        formMessage.className = 'form-message error';
-        formMessage.style.display = 'block';
-
-        // Reset button
-        submitBtn.disabled = false;
-        submitBtn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
-    }
-}
-
-// Gather edit form data
-function gatherEditFormData() {
-    const locationSelect = document.getElementById('editLocation');
-    const customLocationInput = document.getElementById('editCustomLocation');
-    const locationValue = locationSelect?.value === 'other'
-        ? customLocationInput?.value
-        : locationSelect?.value;
-
-    const gamesInput = document.getElementById('editSelectedGamesInput');
-    const leagueDropdown = document.getElementById('editEventLeagueDropdown'); 
-
-    return {
-        event_id: EventState.currentEventId,
-        event_name: document.getElementById('editEventName')?.value,
-        event_type: document.getElementById('editEventType')?.value,
-        games: gamesInput?.value || '[]',
-        event_date: document.getElementById('editDate')?.value,
-        start_time: document.getElementById('editStartTime')?.value,
-        end_time: document.getElementById('editEndTime')?.value,
-        location: locationValue,
-        description: document.getElementById('editDescription')?.value,
-        league_id: leagueDropdown?.value || null  
-    };
-}
-
-// Cancel edit mode
-function cancelEdit() {
-    const content = document.getElementById('eventDetailsContent');
-    const editForm = document.getElementById('eventEditForm');
-
-    setElementDisplay(content, 'block');
-    setElementDisplay(editForm, 'none');
-
-    // Restore buttons if user has permissions
-    if (EventState.currentEventData) {
-        updateEventModalButtons(EventState.currentEventData);
-    }
-}
-
-// ============================================
 // DELETE EVENT
 // ============================================
-
-// Open delete confirmation modal for events
 async function openDeleteEventModal(eventId, eventName) {
     EventState.currentDeleteEventId = eventId;
     EventState.currentDeleteEventName = eventName;
@@ -2690,6 +2007,7 @@ function convertTo24Hour(time12h) {
     return `${hours.toString().padStart(2, '0')}:${minutes}`;
 }
 
+// Determines from which direction the event filter submenu pops out from
 function positionFlyout(triggerEl) {
     const flyout = triggerEl.querySelector('.filter-box-flyout');
     if (!flyout) return;
@@ -2706,9 +2024,9 @@ function positionFlyout(triggerEl) {
     flyout.style.display = '';
 }
 
-/* ========================================
-   HELPERS
-   ======================================== */
+// ===================================
+// HELPERS
+// ===================================
 
 // Check if current user can delete an event
 function canUserDeleteEvent(event) {
@@ -2790,10 +2108,6 @@ window.initializeEventsModule = initializeEventsModule;
 window.loadEvents = loadEvents;
 window.filterEvents = filterEvents;
 
-// Event Modal Functions
-window.openEventModal = openEventModal;
-window.closeEventModal = closeEventModal;
-
 // Day Modal Functions (Calendar)
 window.openDayModal = openDayModal;
 window.closeDayModal = closeDayModal;
@@ -2803,10 +2117,6 @@ window.openCreateEventModal = openCreateEventModal;
 window.closeCreateEventModal = closeCreateEventModal;
 window.handleEventTypeChange = handleEventTypeChange;
 window.toggleAllDayEvent = toggleAllDayEvent;
-
-// Edit Event Functions
-window.toggleEditMode = toggleEditMode;
-window.handleEditEventTypeChange = handleEditEventTypeChange;
 
 // Delete Event Functions
 window.deleteEvent = deleteEvent;

--- a/EsportsManagementTool/EsportsManagementTool/static/events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/events.js
@@ -1,21 +1,16 @@
 /**
  * ============================================
- * EVENTS.JS - REFACTORED & CONSOLIDATED
- * ORGANIZED BY CLAUDEAI
+ * events.js
  * ============================================
- * Handles all event-related functionality for the dashboard
- * Including: event loading, filtering, CRUD operations, modals, and notifications
- *
+ * Handles all general event-related functionality
+ * - event loading
+ * - filtering events in the events tab
+ * - CRUD operations for events
  */
 
 // ============================================
 // GLOBAL STATE MANAGEMENT
 // ============================================
-
-/**
- * Centralized state object for all event-related data
- * Prevents global variable sprawl and makes state management clearer
- */
 const EventState = {
     // Current modal context
     currentEventId: null,
@@ -41,9 +36,7 @@ const EventState = {
     // Calendar day modal data
     eventsData: {},
 
-    /**
-     * Reset state to defaults
-     */
+    // Reset state to defaults
     reset() {
         this.currentEventId = null;
         this.currentEventData = null;
@@ -53,9 +46,7 @@ const EventState = {
         this.deletionSource = 'events';
     },
 
-    /**
-     * Update user permissions
-     */
+    // Update user permissions
     setPermissions(isAdmin, isGm, isDeveloper) {
         this.permissions.is_admin = isAdmin;
         this.permissions.is_gm = isGm;
@@ -67,20 +58,14 @@ const EventState = {
 // INITIALIZATION
 // ============================================
 
-/**
- * Initialize events module when DOM is ready
- * @param {Object} eventsDataFromServer - Pre-loaded events data from server
- */
+// Pull events from server
 function initializeEventsModule(eventsDataFromServer) {
     EventState.eventsData = eventsDataFromServer || {};
     attachEventListeners();
     console.log('Events module initialized');
 }
 
-/**
- * Attach all event-related listeners
- * Centralized listener management for easier maintenance
- */
+// Event listener for easier management
 function attachEventListeners() {
     // Events tab click
     const eventsTab = document.querySelector('[data-tab="events"]');
@@ -113,10 +98,7 @@ function attachEventListeners() {
 // API & DATA LOADING
 // ============================================
 
-/**
- * Load events from the server with optional filtering
- * Handles loading states and error cases
- */
+// Load events from server based on filtering criteria
 function loadEvents() {
     const elements = {
         loading: document.getElementById('eventsLoading'),
@@ -133,9 +115,11 @@ function loadEvents() {
     const queryParams = buildEventFilterParams();
 
     // Fetch events
-    fetch(`/api/events?${queryParams}`)
-        .then(response => response.json())
-        .then(data => {
+    Promise.all([
+        fetch(`/api/events?${queryParams}`).then(response => response.json()),
+        loadGamesList()
+    ])
+        .then(([data]) => {
             if (data.success) {
                 EventState.setPermissions(data.is_admin, data.is_developer, data.is_gm);
                 renderEvents(data.events, data.is_admin, data.is_developer, data.is_gm);
@@ -153,10 +137,7 @@ function loadEvents() {
         });
 }
 
-/**
- * Build query parameters for event filtering
- * @returns {string} URL-encoded query string
- */
+// Build different filter options for events
 function buildEventFilterParams() {
     const filterSelect = document.getElementById('eventFilter');
     const filterValue = filterSelect?.value || 'all';
@@ -167,7 +148,6 @@ function buildEventFilterParams() {
     if (PastSeasonFilterState.selectedSeasonId) {
         params += `&season_id=${PastSeasonFilterState.selectedSeasonId}`;
     }
-    // Otherwise, backend will default to active season
 
     // Add event type filter if applicable
     if (filterValue === 'type') {
@@ -184,10 +164,7 @@ function buildEventFilterParams() {
     return params;
 }
 
-/**
- * Load games list from API (cached after first load)
- * @returns {Promise<Array>} Array of game objects
- */
+// Loads games for game filtering
 async function loadGamesList() {
     if (EventState.gamesListCache) {
         return EventState.gamesListCache;
@@ -210,279 +187,9 @@ async function loadGamesList() {
     }
 }
 
-/**
- * Clear the games cache (useful if games are added/updated)
- */
-function clearGamesCache() {
-    EventState.gamesListCache = null;
-}
-
-// ============================================
-// LEAGUE DROPDOWN MANAGEMENT
-// ============================================
-
-/**
- * Load leagues for any dropdown context
- * Centralized league loading to avoid duplication
- * @param {string} dropdownId - ID of the select element
- * @param {number} selectedLeagueId - League to pre-select (optional)
- * @returns {Promise<boolean>} Success status
- */
-async function loadLeaguesForDropdown(dropdownId, selectedLeagueId = null) {
-    const dropdown = document.getElementById(dropdownId);
-    
-    if (!dropdown) {
-        console.warn(`League dropdown ${dropdownId} not found`);
-        return false;
-    }
-    
-    // **UPDATED: If we have a selectedLeagueId, force reload to ensure we set it**
-    const hasRealOptions = dropdown.options.length > 1 && 
-                           dropdown.options[1].value !== '';
-    
-    // Skip loading only if we have options AND no league to select
-    if (hasRealOptions && !selectedLeagueId) {
-        console.log(`Leagues already loaded for ${dropdownId}`);
-        return true;
-    }
-    
-    // Show loading state
-    dropdown.innerHTML = '<option value="">Loading leagues...</option>';
-    dropdown.disabled = true;
-    
-    try {
-        const response = await fetch('/league/all');
-        const data = await response.json();
-        
-        // Always rebuild the dropdown to ensure clean state
-        dropdown.innerHTML = '<option value="">Select league</option>';
-        
-        if (data.leagues && data.leagues.length > 0) {
-            data.leagues.forEach(league => {
-                const option = document.createElement('option');
-                option.value = league.id;
-                option.textContent = league.name;
-                
-                if (selectedLeagueId && league.id === selectedLeagueId) {
-                    option.selected = true;
-                    console.log(`Selected league ${league.id} (${league.name})`);
-                }
-                
-                dropdown.appendChild(option);
-            });
-            console.log(`Loaded ${data.leagues.length} leagues for ${dropdownId}`);
-            return true;
-        } else {
-            dropdown.innerHTML = '<option value="">No leagues available</option>';
-            console.warn(`No leagues found for ${dropdownId}`);
-            return false;
-        }
-    } catch (error) {
-        console.error('Error loading leagues:', error);
-        dropdown.innerHTML = '<option value="">Error loading leagues</option>';
-        return false;
-    } finally {
-        dropdown.disabled = false;
-    }
-}
-
-/**
- * Show/hide and configure league field based on event type
- * @param {string} context - 'create' or 'edit'
- */
-function handleLeagueFieldVisibility(context) {
-    const prefix = context === 'edit' ? 'edit' : '';
-    const eventTypeId = prefix ? `${prefix}EventType` : 'eventType';
-    const leagueGroupId = prefix ? `${prefix}EventLeagueFieldGroup` : 'eventLeagueFieldGroup';
-    const leagueDropdownId = prefix ? `${prefix}EventLeagueDropdown` : 'eventLeagueDropdown';
-    
-    const eventTypeSelect = document.getElementById(eventTypeId);
-    const leagueGroup = document.getElementById(leagueGroupId);
-    const leagueDropdown = document.getElementById(leagueDropdownId);
-    
-    if (!eventTypeSelect || !leagueGroup || !leagueDropdown) {
-        console.warn(`League field elements not found for context: ${context}`);
-        return;
-    }
-    
-    const eventType = eventTypeSelect.value;
-    const isMatch = eventType === 'Match';
-    
-    // Show/hide league field
-    leagueGroup.style.display = isMatch ? 'flex' : 'none';
-    
-    // Update required attribute
-    if (isMatch) {
-        leagueDropdown.setAttribute('required', 'required');
-        
-        // Update label to show required
-        const label = leagueGroup.querySelector('label');
-        if (label && !label.innerHTML.includes('*')) {
-            label.innerHTML = 'League <span style="color: #ff5252;">*</span>';
-        }
-        
-        // Load leagues if not already loaded
-        loadLeaguesForDropdown(leagueDropdownId);
-    } else {
-        leagueDropdown.removeAttribute('required');
-        leagueDropdown.value = '';
-        
-        // Update label to show optional
-        const label = leagueGroup.querySelector('label');
-        if (label) {
-            label.textContent = 'League (Optional)';
-        }
-    }
-}
-
-// ============================================
-// UTILITY FUNCTIONS
-// ============================================
-
-/**
- * Set element display style (with null check)
- * @param {HTMLElement|null} element - Element to modify
- * @param {string} displayValue - Display value ('block', 'none', etc.)
- */
-function setElementDisplay(element, displayValue) {
-    if (element) element.style.display = displayValue;
-}
-
-/**
- * Enable a dropdown element (re-enable after loading state)
- * @param {HTMLElement|null} dropdown - Dropdown element to enable
- */
-function enableDropdown(dropdown) {
-    if (dropdown) dropdown.disabled = false;
-}
-
-/**
- * Escape single quotes in strings for safe HTML attribute use
- * @param {string} str - String to escape
- * @returns {string} Escaped string
- */
-function escapeQuotes(str) {
-    return str.replace(/'/g, "\\'");
-}
-
-/**
- * Convert 12-hour time format to 24-hour format for input[type="time"]
- * @param {string} time12h - Time in 12-hour format (e.g., "2:30 PM")
- * @returns {string} Time in 24-hour format (e.g., "14:30")
- */
-function convertTo24Hour(time12h) {
-    if (!time12h) return '';
-
-    const [time, period] = time12h.split(' ');
-    let [hours, minutes] = time.split(':');
-
-    hours = parseInt(hours);
-
-    if (period === 'PM' && hours !== 12) {
-        hours += 12;
-    } else if (period === 'AM' && hours === 12) {
-        hours = 0;
-    }
-
-    return `${hours.toString().padStart(2, '0')}:${minutes}`;
-}
-
-/**
- * Check if current user can delete an event
- * Time-based deletion (24-hour window for creators, always for developers)
- * @param {Object} event - Event object
- * @returns {boolean} True if user can delete
- */
-function canUserDeleteEvent(event) {
-    const is_developer = window.userPermissions?.is_developer || false;
-    const is_gm = window.userPermissions?.is_gm || false;
-    const is_admin = window.userPermissions?.is_admin || false;
-    const sessionUserId = window.currentUserId || 0;
-
-    // Developers can always delete
-    if (is_developer) {
-        return true;
-    }
-
-    // Check if within 24-hour window
-    if (!event.created_at) {
-        return false;
-    }
-
-    const createdAt = new Date(event.created_at);
-    const now = new Date();
-    const hoursSinceCreation = (now - createdAt) / (1000 * 60 * 60);
-    const within24Hours = hoursSinceCreation <= 24;
-
-    // Admins can delete ANY event within 24 hours
-    if (is_admin) {
-        return within24Hours;
-    }
-
-    // GMs can only delete events they created (within 24-hour window)
-    if (is_gm) {
-        // Must be the creator
-        if (event.created_by !== sessionUserId) {
-            return false;
-        }
-
-        return within24Hours; // FIXED: Use within24Hours instead of canDelete
-    }
-
-    // Non-GM, non-admin, non-developer users cannot delete
-    return false;
-}
-
-/**
- * Get time remaining for deletion window
- * @param {string} createdAt - ISO timestamp of creation
- * @returns {string} Human-readable time remaining
- */
-function getDeletionTimeRemaining(createdAt) {
-    if (!createdAt) return null;
-
-    const created = new Date(createdAt);
-    const now = new Date();
-    const deletionDeadline = new Date(created.getTime() + (24 * 60 * 60 * 1000));
-
-    if (now >= deletionDeadline) {
-        return null; // Window expired
-    }
-
-    const msRemaining = deletionDeadline - now;
-    const hoursRemaining = Math.floor(msRemaining / (1000 * 60 * 60));
-    const minutesRemaining = Math.floor((msRemaining % (1000 * 60 * 60)) / (1000 * 60));
-
-    if (hoursRemaining > 0) {
-        return `${hoursRemaining}h ${minutesRemaining}m remaining`;
-    } else {
-        return `${minutesRemaining}m remaining`;
-    }
-}
-
-/**
- * Check if current user can edit an event
- * @param {Object} event - Event object
- * @returns {boolean} True if user can edit
- */
-function canUserEditEvent(event) {
-    const is_admin = window.userPermissions?.is_admin || false;
-    const is_developer = window.userPermissions?.is_developer || false;
-    const is_gm = window.userPermissions?.is_gm || false;
-    const sessionUserId = window.currentUserId || 0;
-    return is_admin || is_developer || (is_gm && event.created_by === sessionUserId);
-}
-
-// ============================================
-// GAME TAG SYSTEM - UNIFIED FOR CREATE & EDIT
-// ============================================
-// This section consolidates all game selection logic
-// Both create and edit modals use the same tag system
-
-/**
- * Game tag configuration object
- * Defines element IDs for different contexts (create vs edit)
- */
+/* ===============================
+   Game Dropdown Tag System
+   =============================== */
 const GameTagConfig = {
     create: {
         dropdown: 'gameDropdown',
@@ -567,11 +274,7 @@ async function initializeGameTagSelector(context = 'create', preSelectedGames = 
     }
 }
 
-/**
- * Attach change listener to game dropdown
- * @param {HTMLElement} dropdown - The dropdown element
- * @param {string} context - Either 'create' or 'edit'
- */
+// Attach change listeners for game dropdown
 function attachGameDropdownListener(dropdown, context) {
     // Remove existing listener by cloning
     const clone = dropdown.cloneNode(true);
@@ -590,11 +293,7 @@ function attachGameDropdownListener(dropdown, context) {
     });
 }
 
-/**
- * Add a game tag to the selected games
- * @param {string} gameTitle - Title of game to add
- * @param {string} context - Either 'create' or 'edit'
- */
+// Add a tag to selected games for an event
 function addGameTag(gameTitle, context = 'create') {
     if (EventState.selectedGames.includes(gameTitle)) return;
 
@@ -604,11 +303,7 @@ function addGameTag(gameTitle, context = 'create') {
     updateDropdownOptions(context);
 }
 
-/**
- * Remove a game tag from selected games
- * @param {string} gameTitle - Title of game to remove
- * @param {string} context - Either 'create' or 'edit'
- */
+// Remove a tag from the selected games
 function removeGameTag(gameTitle, context = 'create') {
     EventState.selectedGames = EventState.selectedGames.filter(game => game !== gameTitle);
     updateGameTagsDisplay(context);
@@ -616,10 +311,7 @@ function removeGameTag(gameTitle, context = 'create') {
     updateDropdownOptions(context);
 }
 
-/**
- * Update the visual display of selected game tags
- * @param {string} context - Either 'create' or 'edit'
- */
+// Update display of selected games
 function updateGameTagsDisplay(context = 'create') {
     const config = GameTagConfig[context];
     const container = document.getElementById(config.container);
@@ -644,10 +336,7 @@ function updateGameTagsDisplay(context = 'create') {
     });
 }
 
-/**
- * Update dropdown options to hide already-selected games
- * @param {string} context - Either 'create' or 'edit'
- */
+// Update dropdown when games are selected or deselected
 function updateDropdownOptions(context = 'create') {
     const config = GameTagConfig[context];
     const dropdown = document.getElementById(config.dropdown);
@@ -670,10 +359,7 @@ function updateDropdownOptions(context = 'create') {
     });
 }
 
-/**
- * Update the hidden input with selected games as JSON
- * @param {string} context - Either 'create' or 'edit'
- */
+// Update list of hidden games as games are selected or deselected
 function updateHiddenGamesInput(context = 'create') {
     const config = GameTagConfig[context];
     const hiddenInput = document.getElementById(config.hiddenInput);
@@ -682,10 +368,7 @@ function updateHiddenGamesInput(context = 'create') {
     }
 }
 
-/**
- * Clear all selected games
- * @param {string} context - Either 'create' or 'edit'
- */
+// Clear all selected games
 function clearSelectedGames(context = 'create') {
     EventState.selectedGames = [];
     updateGameTagsDisplay(context);
@@ -693,17 +376,20 @@ function clearSelectedGames(context = 'create') {
     updateDropdownOptions(context);
 }
 
-// ============================================
-// SINGLE-SELECT GAME DROPDOWN (FOR FILTERS)
-// ============================================
+/* ===============================
+   Event Filtering
+   =============================== */
 
-/**
- * Populate a single-select dropdown with games
- * Used for filtering, not for multi-select tag system
- * @param {string} selectId - ID of the select element
- * @param {string} loadingIndicatorId - ID of loading indicator (optional)
- * @param {string} selectedGame - Game to pre-select (optional)
- */
+// Global state for season filtering
+const PastSeasonFilterState = {
+    selectedSeasonId: null,
+    selectedSeasonName: '',
+    availablePastSeasons: [],
+    secondaryFilter: 'all',
+    isFilteringPastSeason: false
+};
+
+// Populate single-select game dropdown for filter
 async function populateGameDropdown(selectId, loadingIndicatorId = null, selectedGame = null) {
     const selectElement = document.getElementById(selectId);
     if (!selectElement) return;
@@ -742,29 +428,12 @@ async function populateGameDropdown(selectId, loadingIndicatorId = null, selecte
     }
 }
 
-/**
- * Load games for filter dropdown
- */
+// Load games for filter dropdown
 async function loadGamesForFilter() {
     await populateGameDropdown('gameFilter', 'gameFilterLoadingIndicator');
 }
 
-// ============================================
-// EVENT FILTERING
-// ============================================
-
-// Global state for season filtering
-const PastSeasonFilterState = {
-    selectedSeasonId: null,
-    selectedSeasonName: '',
-    availablePastSeasons: [],
-    secondaryFilter: 'all',
-    isFilteringPastSeason: false
-};
-
-/**
- * Load past seasons for filtering (admin/dev only)
- */
+// Load past seasons filter
 async function loadPastSeasonsForFilter() {
     const seasonSelect = document.getElementById('pastSeasonSelect');
     const loadingIndicator = document.getElementById('pastSeasonLoadingIndicator');
@@ -808,10 +477,7 @@ async function loadPastSeasonsForFilter() {
     }
 }
 
-/**
- * Filter events based on dropdown selection
- * Manages visibility of secondary filter dropdowns
- */
+// Filter events based on dropdown selection
 function filterEvents() {
     const filterSelect = document.getElementById('eventFilter');
     const filterValue = filterSelect?.value || 'all';
@@ -869,9 +535,7 @@ function filterEvents() {
     SEASON FILTERING STUFF
    ================================ */
 
-/**
- * Handle past season selection
- */
+// Handle past season selection
 function handlePastSeasonSelection() {
     const seasonSelect = document.getElementById('pastSeasonSelect');
     const seasonId = seasonSelect?.value;
@@ -904,9 +568,7 @@ function handlePastSeasonSelection() {
     updateFilterColumnsCount();
 }
 
-/**
- * Filter events by past season and secondary filter
- */
+// Filter events by past season and secondary filter
 function filterEventsByPastSeason() {
     const secondaryFilter = document.getElementById('pastSeasonSecondaryFilter');
     const secondaryValue = secondaryFilter?.value || 'all';
@@ -936,9 +598,7 @@ function filterEventsByPastSeason() {
     updateFilterColumnsCount();
 }
 
-/**
- * Filter by past season and type
- */
+// Filter by past season and type
 function filterBySeasonAndType() {
     const typeFilter = document.getElementById('eventTypeFilter');
     if (typeFilter?.value) {
@@ -946,9 +606,7 @@ function filterBySeasonAndType() {
     }
 }
 
-/**
- * Filter by past season and game
- */
+// Filter by past season and game
 function filterBySeasonAndGame() {
     const gameFilter = document.getElementById('gameFilter');
     if (gameFilter?.value) {
@@ -956,9 +614,7 @@ function filterBySeasonAndGame() {
     }
 }
 
-/**
- * Handle type filter change - routes to correct function based on context
- */
+// Handle type filter change - routes to correct function based on context
 function handleTypeFilterChange() {
     if (PastSeasonFilterState.isFilteringPastSeason) {
         filterBySeasonAndType();
@@ -967,9 +623,7 @@ function handleTypeFilterChange() {
     }
 }
 
-/**
- * Handle game filter change - routes to correct function based on context
- */
+// Handle game filter change - routes to correct function based on context
 function handleGameFilterChange() {
     if (PastSeasonFilterState.isFilteringPastSeason) {
         filterBySeasonAndGame();
@@ -978,9 +632,7 @@ function handleGameFilterChange() {
     }
 }
 
-/**
- * Load events for selected past season with filters
- */
+// Load events for selected past season with filters
 function loadEventsForPastSeason() {
     if (!PastSeasonFilterState.selectedSeasonId) {
         console.warn('No past season selected');
@@ -1045,9 +697,7 @@ function loadEventsForPastSeason() {
         });
 }
 
-/**
- * Update empty state message for past season filtering
- */
+// Update empty state message for past season filtering
 function updatePastSeasonEmptyStateMessage() {
     const emptyStateDiv = document.getElementById('eventsEmptyState');
     const emptyStateTitle = emptyStateDiv?.querySelector('h3');
@@ -1080,9 +730,7 @@ function updatePastSeasonEmptyStateMessage() {
     emptyStateText.textContent = text;
 }
 
-/**
- * Filter events by type (called when type dropdown changes)
- */
+// Filter events by type (called when type dropdown changes)
 function filterEventsByType() {
     const typeFilterSelect = document.getElementById('eventTypeFilter');
     if (typeFilterSelect?.value) {
@@ -1090,9 +738,7 @@ function filterEventsByType() {
     }
 }
 
-/**
- * Filter events by game (called when game dropdown changes)
- */
+// Filter events by game (called when game dropdown changes)
 function filterEventsByGame() {
     const gameFilterSelect = document.getElementById('gameFilter');
     if (gameFilterSelect?.value) {
@@ -1119,12 +765,7 @@ function updateFilterColumnsCount() {
 // EVENT RENDERING
 // ============================================
 
-/**
- * Render events in the grid
- * @param {Array} events - Array of event objects
- * @param {boolean} isAdmin - Whether user is admin
- * @param {boolean} isGm - Whether user is GM
- */
+// Render events in the grid
 function renderEvents(events, isAdmin, isGm) {
     const containerDiv = document.getElementById('eventsContainer');
     const emptyStateDiv = document.getElementById('eventsEmptyState');
@@ -1141,75 +782,46 @@ function renderEvents(events, isAdmin, isGm) {
     }</div>`;
 
     containerDiv.innerHTML = gridHTML;
+
+    // Open detail panel on card click (not the modal)
+    containerDiv.querySelectorAll('.event-card').forEach(card => {
+        card.addEventListener('click', (e) => {
+            openEventDetailPanel(parseInt(card.dataset.eventId));
+        });
+    });
+
     setElementDisplay(containerDiv, 'block');
     setElementDisplay(emptyStateDiv, 'none');
 }
 
+// Builds individual event cards
 function createEventCard(event, isAdmin, isGm) {
     const canDelete = canUserDeleteEvent(event);
-
     const ongoingIndicator = event.is_ongoing
         ? '<div class="event-ongoing-indicator" title="Event is currently ongoing"></div>'
         : '';
 
-    // Build delete button
-    let deleteButton = '';
-    if (canDelete) {
-        deleteButton = `
-            <button class="btn btn-secondary btn-delete"
-                    onclick="event.stopPropagation(); openDeleteEventModal(${event.id}, '${escapeQuotes(event.name)}')">
-                <i class="fas fa-trash"></i>
-            </button>
-        `;
-    }
-
-    const gameDisplay = formatGameDisplay(event.game);
+    const gameDisplay = formatGameDisplay(event.game, event.team_name, event.is_scheduled);
     const eventTypeClass = (event.event_type || 'event').toLowerCase();
     const scheduledClass = event.is_scheduled ? 'scheduled-event' : '';
-
-    const seasonIndicator = event.season_name ? `
-        <div class="event-season-indicator" title="${event.season_is_active ? 'Active Season' : 'Past Season'}">
-            <span style="color: ${event.season_is_active ? '#22c55e' : '#94a3b8'};">●</span>
-            ${event.season_name}
-        </div>
-    ` : '';
+    const timeDisplay = event.start_time ? event.start_time : '';
 
     return `
-        <div class="event-card ${scheduledClass}"
-             data-event-type="${eventTypeClass}"
-             ${event.is_scheduled ? `data-scheduled="true" data-schedule-id="${event.schedule_id}"` : ''}
-             onclick="openEventModal(${event.id})">
+        <div class="event-card ${scheduledClass}" data-event-type="${eventTypeClass}" data-event-id="${event.id}" ...>
             ${ongoingIndicator}
-            <div class="event-card-header">
-                <h3 class="event-card-title">${event.name}</h3>
-                ${seasonIndicator}
+            <div class="event-card-top">
+                <span class="event-card-name">${event.name}</span>
+                <span class="event-card-game">${gameDisplay}</span>
             </div>
-
-            <div class="event-card-details">
-                ${createEventDetailRow('calendar', 'Date', event.date)}
-                ${event.start_time ? createEventDetailRow('clock', 'Time', `${event.start_time} - ${event.end_time}`) : ''}
-                ${createEventDetailRow('tag', 'Type', `<span class="event-type-badge" data-type="${eventTypeClass}">${event.event_type}</span>`)}
-                ${createEventDetailRow('gamepad', 'Game', gameDisplay)}
-                ${createEventDetailRow('map-marker-alt', 'Location', event.location)}
-            </div>
-
-            <div class="event-card-actions">
-                <button class="btn btn-primary" onclick="event.stopPropagation(); openEventModal(${event.id})">
-                    <i class="fas fa-eye"></i> View Details
-                </button>
-                ${deleteButton}
+            <div class="event-card-bottom">
+                <span class="event-card-date"><i class="fas fa-calendar"></i>${event.date}</span>
+                ${timeDisplay ? `<span class="event-card-time">${timeDisplay}</span>` : ''}
             </div>
         </div>
     `;
 }
 
-/**
- * Create a detail row for event card
- * @param {string} icon - FontAwesome icon name (without 'fa-' prefix)
- * @param {string} label - Label text
- * @param {string} value - Value HTML
- * @returns {string} HTML string for detail row
- */
+// Create a detail row for event card
 function createEventDetailRow(icon, label, value) {
     return `
         <div class="event-detail-row">
@@ -1222,24 +834,22 @@ function createEventDetailRow(icon, label, value) {
     `;
 }
 
-/**
- * Format game display (truncate if multiple games)
- * @param {string} gameStr - Comma-separated game string
- * @returns {string} Formatted game display string
- */
-function formatGameDisplay(gameStr) {
-    if (!gameStr || gameStr === 'N/A') return 'None';
-
-    const games = gameStr.split(', ');
-    if (games.length > 2) {
-        return `${games.slice(0, 2).join(', ')} +${games.length - 2} more`;
-    }
-    return gameStr;
+// Look up a game's abbreviation from the cached games list
+function getGameAbbreviation(title) {
+    const game = EventState.gamesListCache?.find(g => g.GameTitle === title);
+    return game?.Abbreviation || title; // fall back to full title if not found/not loaded yet
 }
 
-/**
- * Update empty state message based on current filter
- */
+// Format game display: first game's abbreviation, plus a count of any others
+function formatGameDisplay(gameStr, teamName, isScheduled) {
+    if (isScheduled && teamName) return teamName;
+    if (!gameStr || gameStr === 'N/A') return '';
+
+    const games = gameStr.split(', ').map(getGameAbbreviation);
+    return games.length > 1 ? `${games[0]} +${games.length - 1}` : games[0];
+}
+
+// Update empty state message based on current filter
 function updateEmptyStateMessage() {
     const emptyStateDiv = document.getElementById('eventsEmptyState');
     const filterSelect = document.getElementById('eventFilter');
@@ -1256,11 +866,7 @@ function updateEmptyStateMessage() {
     emptyStateText.textContent = message.text;
 }
 
-/**
- * Get empty state message based on filter type
- * @param {string} filterValue - Current filter value
- * @returns {Object} Object with title and text properties
- */
+// Get empty state message based on filter type
 function getEmptyStateMessage(filterValue) {
     const messages = {
         subscribed: {
@@ -1320,9 +926,7 @@ function getEmptyStateMessage(filterValue) {
     };
 }
 
-/**
- * Show error state when events fail to load
- */
+// Show error state when events fail to load
 function showEventsError() {
     const containerDiv = document.getElementById('eventsContainer');
     if (!containerDiv) return;
@@ -1387,14 +991,7 @@ async function openEventModal(eventId, source = 'events') {
     }
 }
 
-/**
- * Set modal loading state
- * @param {HTMLElement} modal - Modal element
- * @param {HTMLElement} spinner - Spinner element
- * @param {HTMLElement} content - Content element
- * @param {HTMLElement} deleteBtn - Delete button element
- * @param {boolean} isLoading - Whether modal is loading
- */
+// Set modal loading state
 function setModalLoadingState(modal, spinner, content, deleteBtn, isLoading) {
     modal.style.display = 'block';
     setElementDisplay(spinner, isLoading ? 'block' : 'none');
@@ -1403,11 +1000,7 @@ function setModalLoadingState(modal, spinner, content, deleteBtn, isLoading) {
     document.body.style.overflow = 'hidden';
 }
 
-/**
- * Build event details HTML
- * @param {Object} event - Event object
- * @returns {string} HTML string for event details
- */
+// Build event details HTML
 function buildEventDetailsHTML(event) {
     const sections = [];
 
@@ -1458,14 +1051,124 @@ function buildEventDetailsHTML(event) {
     return `<div class="event-detail-grid">${sections.join('')}</div>`;
 }
 
-/**
- * Create a detail section for event modal
- * @param {string} icon - FontAwesome icon name
- * @param {string} title - Section title
- * @param {string} content - Section content
- * @param {boolean} fullWidth - Whether section spans full width
- * @returns {string} HTML string for detail section
- */
+// Populate the right-hand detail panel when a card is clicked
+async function openEventDetailPanel(eventId) {
+    const pane = document.getElementById('eventsDetailPane');
+    EventState.currentEventId = eventId;
+
+    // Show loading state
+    pane.innerHTML = `
+        <div class="events-detail-placeholder">
+            <i class="fas fa-spinner fa-spin"></i>
+            <p>Loading event...</p>
+        </div>
+    `;
+
+    try {
+        const response = await fetch(`/api/event/${eventId}`);
+        if (!response.ok) throw new Error('Failed to fetch event');
+        const event = await response.json();
+        EventState.currentEventData = event;
+
+        const eventTypeClass = (event.event_type || 'event').toLowerCase();
+
+        // Build detail rows
+        const rows = [];
+
+        if (event.start_time) {
+            const timeStr = `${event.start_time}${event.end_time ? ' – ' + event.end_time : ''}`;
+            rows.push(detailRow('clock', 'Time', timeStr));
+        }
+
+        if (event.game && event.game !== 'N/A') {
+            rows.push(detailRow('gamepad', 'Game', event.game));
+        }
+
+        if (event.event_type === 'Match' && event.league_name) {
+            rows.push(detailRow('trophy', 'League', event.league_name));
+        }
+
+        if (event.location) {
+            rows.push(detailRow('map-marker-alt', 'Location', event.location));
+        }
+
+        if (event.description) {
+            rows.push(detailRow('info-circle', 'Description', event.description));
+        }
+
+        pane.innerHTML = `
+            <div class="events-detail-panel" data-event-type="${eventTypeClass}">
+                <div class="events-detail-banner-wrapper">
+                    <div class="events-detail-banner">
+                        <i class="fas fa-image"></i>&nbsp; Banner coming soon
+                    </div>
+                    <div class="events-detail-banner-actions">
+                        ${canUserEditEvent(event) ? `
+                            <button class="events-detail-banner-btn" title="Edit event"
+                                    onclick="toggleEditMode()">
+                                <i class="fas fa-edit"></i>
+                            </button>` : ''}
+                        ${canUserDeleteEvent(event) ? `
+                            <button class="events-detail-banner-btn delete" title="Delete event"
+                                    onclick="openDeleteEventModal(${event.id}, '${escapeQuotes(event.name)}')">
+                                <i class="fas fa-trash"></i>
+                            </button>` : ''}
+                    </div>
+                </div>
+                <h2 class="events-detail-title">${event.name}</h2>
+                <div class="events-detail-sections">
+                    <div class="events-detail-row">
+                        <div class="event-detail-icon"><i class="fas fa-calendar-alt"></i></div>
+                        <div class="events-detail-row-text">
+                            <h4>Date</h4>
+                            <p>${event.date}</p>
+                        </div>
+                        <span class="game-next-event-type ${eventTypeClass} events-detail-type-badge">${event.event_type || 'Event'}</span>
+                    </div>
+                    ${rows.join('')}
+                </div>
+                <div class="notification-opt-in">
+                    <div class="notification-icon"><i class="fas fa-bell"></i></div>
+                    <div class="notification-text">
+                        <div class="title">Event Reminders</div>
+                        <div class="subtitle">Get notified about this event</div>
+                    </div>
+                    <button class="notification-btn" id="detailSubscribeBtn"
+                            onclick="toggleEventSubscription()">
+                        <span id="detailSubscribeBtnText">Loading...</span>
+                    </button>
+                </div>
+            </div>
+        `;
+
+        // Reuse the existing notification loader to set subscribe button state
+        await loadNotificationSection(eventId);
+
+    } catch (error) {
+        console.error('Error loading event detail panel:', error);
+        pane.innerHTML = `
+            <div class="events-detail-placeholder">
+                <i class="fas fa-exclamation-circle"></i>
+                <p>Failed to load event details.</p>
+            </div>
+        `;
+    }
+}
+
+// Build a single detail row for the panel
+function detailRow(icon, label, value) {
+    return `
+        <div class="events-detail-row">
+            <div class="event-detail-icon"><i class="fas fa-${icon}"></i></div>
+            <div class="events-detail-row-text">
+                <h4>${label}</h4>
+                <p>${value}</p>
+            </div>
+        </div>
+    `;
+}
+
+// Create a detail section for event modal
 function createDetailSection(icon, title, content, fullWidth = false) {
     const style = fullWidth ? ' style="grid-column: 1 / -1;"' : '';
     return `
@@ -1479,10 +1182,7 @@ function createDetailSection(icon, title, content, fullWidth = false) {
     `;
 }
 
-/**
- * Create notification section HTML
- * @returns {string} HTML string for notification section
- */
+// Create notification section HTML
 function createNotificationSection() {
     return `
         <div class="event-notification-section full-width"
@@ -1504,9 +1204,7 @@ function createNotificationSection() {
     `;
 }
 
-/**
- * Update edit/delete buttons based on permissions
- */
+// Update edit/delete buttons based on permissions
 function updateEventModalButtons(event) {
     const editBtn = document.getElementById("editEventBtn");
     const deleteBtn = document.getElementById("deleteEventBtn");
@@ -1536,12 +1234,7 @@ function updateEventModalButtons(event) {
     }
 }
 
-/**
- * Handle event load error
- * @param {HTMLElement} titleElement - Title element
- * @param {HTMLElement} content - Content element
- * @param {HTMLElement} spinner - Spinner element
- */
+// Handle event load error
 function handleEventLoadError(titleElement, content, spinner) {
     if (titleElement) {
         titleElement.textContent = 'Error Loading Event';
@@ -1559,161 +1252,17 @@ function handleEventLoadError(titleElement, content, spinner) {
     setElementDisplay(content, 'block');
 }
 
-/**
- * Close event details modal
- */
-function closeEventModal() {
-    const modal = document.getElementById('eventDetailsModal');
-    const deleteBtn = document.getElementById("deleteEventBtn");
-    const editBtn = document.getElementById("editEventBtn");
-    const content = document.getElementById("eventDetailsContent");
-    const editForm = document.getElementById("eventEditForm");
-
-    // Hide modal and its elements
-    setElementDisplay(modal, 'none');
-    setElementDisplay(deleteBtn, 'none');
-    setElementDisplay(editBtn, 'none');
-    setElementDisplay(content, 'none');
-    setElementDisplay(editForm, 'none');
-
-    // Check if there are other modals still open before restoring scroll
-    const openModals = document.querySelectorAll('.modal');
-    const hasOpenModals = Array.from(openModals).some(m => {
-        if (m.id === 'eventDetailsModal') return false;
-        const style = window.getComputedStyle(m);
-        return style.display === 'block' || style.display === 'flex' || m.classList.contains('active');
-    });
-
-    if (!hasOpenModals) {
-        document.body.style.overflow = "auto";
-    }
-
-    EventState.reset();
-}
-
-/**
- * Load leagues for event edit form
- */
-async function loadLeaguesForEventEdit() {
-    const leagueDropdown = document.getElementById('editEventLeagueDropdown');
-    const loadingIndicator = document.getElementById('editEventLeagueLoadingIndicator');
-    
-    if (!leagueDropdown) return;
-    
-    // Don't reload if already populated (more than just the placeholder)
-    if (leagueDropdown.options.length > 1) return;
-    
-    setElementDisplay(loadingIndicator, 'block');
-    leagueDropdown.disabled = true;
-    
-    try {
-        const response = await fetch('/league/all');
-        const data = await response.json();
-        
-        if (data.leagues && data.leagues.length > 0) {
-            // Keep the placeholder and add leagues
-            data.leagues.forEach(league => {
-                const option = document.createElement('option');
-                option.value = league.id;
-                option.textContent = league.name;
-                leagueDropdown.appendChild(option);
-            });
-        } else {
-            leagueDropdown.innerHTML = '<option value="">No leagues available</option>';
-        }
-    } catch (error) {
-        console.error('Error loading leagues for edit:', error);
-        leagueDropdown.innerHTML = '<option value="">Error loading leagues</option>';
-    } finally {
-        setElementDisplay(loadingIndicator, 'none');
-        leagueDropdown.disabled = false;
-    }
-}
-
-// ============================================
-// EVENT NOTIFICATIONS
-// ============================================
-
-/**
- * Load notification section for an event
- * @param {number} eventId - Event ID
- */
-async function loadNotificationSection(eventId) {
-    const btn = document.getElementById('notificationBtn');
-    const btnText = document.getElementById('notificationBtnText');
-
-    if (!btn || !btnText) return;
-
-    try {
-        const response = await fetch(`/api/event/${eventId}/subscription-status`);
-        const data = await response.json();
-
-        // Check if notifications are enabled
-        if (!data.notifications_enabled) {
-            btn.disabled = true;
-            btn.classList.add('disabled');
-            btnText.textContent = 'Enable notifications in Profile';
-            return;
-        }
-
-        // Update subscription status
-        btn.disabled = false;
-        btn.classList.remove('disabled');
-        btn.classList.toggle('subscribed', data.subscribed);
-        btnText.textContent = data.subscribed ? 'Subscribed' : 'Subscribe';
-
-    } catch (err) {
-        console.error('Error fetching subscription status:', err);
-        btn.disabled = true;
-        btnText.textContent = 'Error';
-    }
-}
-
-/**
- * Toggle event subscription
- */
-async function toggleEventSubscription() {
-    const btn = document.getElementById('notificationBtn');
-    const btnText = document.getElementById('notificationBtnText');
-
-    if (!EventState.currentEventId) return;
-
-    try {
-        const response = await fetch(
-            `/api/event/${EventState.currentEventId}/toggle-subscription`,
-            { method: 'POST' }
-        );
-        const data = await response.json();
-
-        if (data.error) {
-            alert(data.error);
-            return;
-        }
-
-        // Update button state
-        const isSubscribed = data.status === 'subscribed';
-        btn.classList.toggle('subscribed', isSubscribed);
-        btnText.textContent = isSubscribed ? 'Subscribed' : 'Subscribe';
-
-    } catch (err) {
-        console.error('Error toggling subscription:', err);
-        alert('Failed to toggle subscription.');
-    }
-}
-
 // ============================================
 // CREATE EVENT MODAL
 // ============================================
 
-/**
- * Open create event modal
- */
+// Open create event modal
 function openCreateEventModal() {
     const modal = document.getElementById('createEventModal');
     const form = document.getElementById('createEventForm');
     const customLocationGroup = document.getElementById('customLocationGroup');
     const formMessage = document.getElementById('formMessage');
-    const leagueGroup = document.getElementById('eventLeagueFieldGroup'); // ADD THIS LINE
+    const leagueGroup = document.getElementById('eventLeagueFieldGroup');
 
     // Show modal
     setElementDisplay(modal, 'block');
@@ -1723,7 +1272,7 @@ function openCreateEventModal() {
     form.reset();
     setElementDisplay(customLocationGroup, 'none');
     setElementDisplay(formMessage, 'none');
-    setElementDisplay(leagueGroup, 'none'); // ADD THIS LINE - Hide league field initially
+    setElementDisplay(leagueGroup, 'none');
     clearSelectedGames('create');
     
     // Character Counter
@@ -1739,20 +1288,14 @@ function openCreateEventModal() {
     }, 50);
 }
 
-/**
- * Close create event modal
- */
+// Close create event modal
 function closeCreateEventModal() {
     const modal = document.getElementById('createEventModal');
     setElementDisplay(modal, 'none');
     document.body.style.overflow = 'auto';
 }
 
-/**
- * Handle location dropdown change
- * Shows/hides custom location input
- * @param {Event} e - Change event
- */
+// Handle location dropdown change
 function handleLocationChange(e) {
     const customLocationGroup = document.getElementById('customLocationGroup');
     const customLocationInput = document.getElementById('customLocation');
@@ -1767,9 +1310,7 @@ function handleLocationChange(e) {
     }
 }
 
-/**
- * Handle event type change - hide game field for Misc events
- */
+// Handle event type change - hide game field for Misc events
 function handleEventTypeChange() {
     const eventType = document.getElementById('eventType')?.value;
     const gameFieldGroup = document.getElementById('gameFieldGroup');
@@ -1781,16 +1322,9 @@ function handleEventTypeChange() {
     } else {
         setElementDisplay(gameFieldGroup, 'block');
     }
-    
-    // Handle league field visibility
-    handleLeagueFieldVisibility('create'); 
 }
 
-/**
- * Toggle all-day event button
- * Switches between "All Day?" and "All Day" states
- * Manages time input states accordingly
- */
+// Toggle all-day event button
 function toggleAllDayEvent() {
     const allDayCheckbox = document.getElementById('allDayEvent');
     const allDayButton = document.getElementById('allDayButton');
@@ -1841,10 +1375,7 @@ function toggleAllDayEvent() {
     }
 }
 
-/**
- * Handle create event form submission
- * @param {Event} e - Submit event
- */
+// Handle create event form submission
 async function handleCreateEventSubmit(e) {
     e.preventDefault();
 
@@ -1914,11 +1445,7 @@ async function handleCreateEventSubmit(e) {
 // DAY MODAL (CALENDAR VIEW)
 // ============================================
 
-/**
- * Open day events modal (for calendar view)
- * @param {string} date - Date string
- * @param {string} dateTitle - Formatted date title
- */
+// Open day events modal
 function openDayModal(date, dateTitle) {
     const modal = document.getElementById('dayEventsModal');
     const modalTitle = document.getElementById('modalDayTitle');
@@ -1943,11 +1470,7 @@ function openDayModal(date, dateTitle) {
     document.body.style.overflow = 'hidden';
 }
 
-/**
- * Create event item for day modal
- * @param {Object} event - Event object
- * @returns {HTMLElement} Event item element
- */
+// Create event item for day modal
 function createDayModalEventItem(event) {
     const eventItem = document.createElement('div');
     eventItem.className = 'modal-event-item';
@@ -1970,9 +1493,7 @@ function createDayModalEventItem(event) {
     return eventItem;
 }
 
-/**
- * Close day modal
- */
+// Close day modal
 function closeDayModal() {
     const modal = document.getElementById('dayEventsModal');
     setElementDisplay(modal, 'none');
@@ -1983,10 +1504,7 @@ function closeDayModal() {
 // EDIT EVENT MODAL
 // ============================================
 
-/**
- * Toggle edit mode
- * Switches from view mode to edit mode in the event modal
- */
+// Toggle edit mode
 function toggleEditMode() {
     const content = document.getElementById('eventDetailsContent');
     const editForm = document.getElementById('eventEditForm');
@@ -2007,9 +1525,7 @@ function toggleEditMode() {
     createEditForm();
 }
 
-/**
- * Create edit form with pre-populated data
- */
+// Create edit form with pre-populated data
 function createEditForm() {
     const editForm = document.getElementById('eventEditForm');
     if (!EventState.currentEventData) return;
@@ -2034,24 +1550,11 @@ function createEditForm() {
         // Handle event type (will show/hide league field)
         handleEditEventTypeChange();
         
-        // Load leagues if this is a Match event
-        if (event.event_type === 'Match') {
-            const dropdown = document.getElementById('editEventLeagueDropdown');
-            if (dropdown) {
-                console.log('Loading leagues for edit event, current league_id:', event.league_id);
-                loadLeaguesForDropdown('editEventLeagueDropdown', event.league_id);
-            } else {
-                console.error('editEventLeagueDropdown not found!');
-            }
-        }
+
     }, 50); // Small delay to ensure DOM is ready
 }
 
-/**
- * Create edit form fields
- * @param {Object} event - Event object
- * @returns {string} HTML string for form fields
- */
+// Create edit form fields
 function createEditFormFields(event) {
     const escapedDescription = (event.description || '')
         .replace(/&/g, '&amp;')
@@ -2187,11 +1690,7 @@ function createEditFormFields(event) {
     `;
 }
 
-/**
- * Create event type options
- * @param {string} selectedType - Currently selected type
- * @returns {string} HTML string for options
- */
+// Create event type options
 function createEventTypeOptions(selectedType) {
     const types = ['Event', 'Match', 'Practice', 'Tournament', 'Misc'];
     return types.map(type =>
@@ -2199,11 +1698,7 @@ function createEventTypeOptions(selectedType) {
     ).join('');
 }
 
-/**
- * Create game tag field
- * @param {string} context - 'create' or 'edit'
- * @returns {string} HTML string for game tag field
- */
+// Create game tag field
 function createGameTagField(context) {
     const prefix = context === 'edit' ? 'edit' : '';
     const idPrefix = prefix ? `${prefix}` : '';
@@ -2231,11 +1726,7 @@ function createGameTagField(context) {
     `;
 }
 
-/**
- * Create time input fields
- * @param {Object} event - Event object
- * @returns {string} HTML string for time fields
- */
+// Create time input fields
 function createTimeFields(event) {
     return `
         <div class="form-row" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
@@ -2253,12 +1744,7 @@ function createTimeFields(event) {
     `;
 }
 
-/**
- * Create location fields
- * @param {string} context - 'create' or 'edit'
- * @param {string} currentLocation - Current location value
- * @returns {string} HTML string for location fields
- */
+// Create location fields
 function createLocationFields(context, currentLocation = '') {
     const prefix = context === 'edit' ? 'edit' : '';
     const idPrefix = prefix ? `${prefix}` : '';
@@ -2286,10 +1772,7 @@ function createLocationFields(context, currentLocation = '') {
     `;
 }
 
-/**
- * Create form action buttons
- * @returns {string} HTML string for action buttons
- */
+// Create form action buttons
 function createFormActionButtons() {
     return `
         <div class="form-actions">
@@ -2303,10 +1786,7 @@ function createFormActionButtons() {
     `;
 }
 
-/**
- * Setup edit location dropdown with current value
- * @param {string} currentLocation - Current location
- */
+// Setup edit location dropdown with current value
 function setupEditLocationDropdown(currentLocation) {
     const presetLocations = [
         'Campus Center',
@@ -2347,9 +1827,7 @@ function setupEditLocationDropdown(currentLocation) {
     });
 }
 
-/**
- * Handle event type change in edit form
- */
+// Handle event type change in edit form
 function handleEditEventTypeChange() {
     const eventType = document.getElementById('editEventType')?.value;
     const gameFieldGroup = document.getElementById('editGameFieldGroup');
@@ -2395,8 +1873,7 @@ function handleEditEventTypeChange() {
             label.innerHTML = 'League <span style="color: #ff5252;">*</span>';
         }
         
-        // Load leagues if not already loaded
-        loadLeaguesForDropdown('editEventLeagueDropdown');
+
     } else {
         leagueDropdown.removeAttribute('required');
         leagueDropdown.value = '';
@@ -2410,9 +1887,7 @@ function handleEditEventTypeChange() {
 }
 
 
-/**
- * Submit event edit
- */
+// Submit edit event
 async function submitEventEdit() {
     const formMessage = document.getElementById('editFormMessage');
     const submitBtn = document.querySelector('#editEventFormData .btn-primary');
@@ -2472,10 +1947,7 @@ async function submitEventEdit() {
     }
 }
 
-/**
- * Gather edit form data
- * @returns {Object} Form data object
- */
+// Gather edit form data
 function gatherEditFormData() {
     const locationSelect = document.getElementById('editLocation');
     const customLocationInput = document.getElementById('editCustomLocation');
@@ -2500,9 +1972,7 @@ function gatherEditFormData() {
     };
 }
 
-/**
- * Cancel edit mode
- */
+// Cancel edit mode
 function cancelEdit() {
     const content = document.getElementById('eventDetailsContent');
     const editForm = document.getElementById('eventEditForm');
@@ -2520,10 +1990,7 @@ function cancelEdit() {
 // DELETE EVENT
 // ============================================
 
-/**
- * Open delete confirmation modal for events
- * Uses universal delete modal system
- */
+// Open delete confirmation modal for events
 async function openDeleteEventModal(eventId, eventName) {
     EventState.currentDeleteEventId = eventId;
     EventState.currentDeleteEventName = eventName;
@@ -2567,10 +2034,7 @@ async function openDeleteEventModal(eventId, eventName) {
     });
 }
 
-/**
- * Function triggered when an event is confirmed to be deleted.
- * @param - eventId is the ID of the event being deleted.
- **/
+// Function triggered when an event is confirmed to be deleted
 async function confirmDeleteEvent(eventId) {
     try {
         const response = await fetch(`/api/events/${eventId}`, {
@@ -2632,9 +2096,7 @@ async function confirmDeleteEvent(eventId) {
     }
 }
 
-/**
- * Handle delete error messages
- */
+// Handle delete error messages
 function handleDeleteError(message) {
     window.closeDeleteConfirmModal();
 
@@ -2647,10 +2109,7 @@ function handleDeleteError(message) {
     }
 }
 
-/**
- * Delete event (called from event details modal)
- * Uses the same confirmation modal as card deletion
- */
+// Delete event (called from event details modal)
 async function deleteEvent() {
     if (!EventState.currentEventId) {
         alert("Event ID not found.");
@@ -2683,18 +2142,124 @@ async function deleteEvent() {
 }
 
 // ============================================
+// UTILITY FUNCTIONS
+// ============================================
+
+// Set element display style (with null check)
+function setElementDisplay(element, displayValue) {
+    if (element) element.style.display = displayValue;
+}
+
+// Escape single quotes in strings for safe HTML attribute use
+function escapeQuotes(str) {
+    return str.replace(/'/g, "\\'");
+}
+
+// Convert 12-hour time format to 24-hour format for input[type="time"]
+function convertTo24Hour(time12h) {
+    if (!time12h) return '';
+
+    const [time, period] = time12h.split(' ');
+    let [hours, minutes] = time.split(':');
+
+    hours = parseInt(hours);
+
+    if (period === 'PM' && hours !== 12) {
+        hours += 12;
+    } else if (period === 'AM' && hours === 12) {
+        hours = 0;
+    }
+
+    return `${hours.toString().padStart(2, '0')}:${minutes}`;
+}
+
+/* ========================================
+   HELPERS
+   ======================================== */
+
+// Check if current user can delete an event
+function canUserDeleteEvent(event) {
+    const is_developer = window.userPermissions?.is_developer || false;
+    const is_gm = window.userPermissions?.is_gm || false;
+    const is_admin = window.userPermissions?.is_admin || false;
+    const sessionUserId = window.currentUserId || 0;
+
+    // Developers can always delete
+    if (is_developer) {
+        return true;
+    }
+
+    // Check if within 24-hour window
+    if (!event.created_at) {
+        return false;
+    }
+
+    const createdAt = new Date(event.created_at);
+    const now = new Date();
+    const hoursSinceCreation = (now - createdAt) / (1000 * 60 * 60);
+    const within24Hours = hoursSinceCreation <= 24;
+
+    // Admins can delete ANY event within 24 hours
+    if (is_admin) {
+        return within24Hours;
+    }
+
+    // GMs can only delete events they created (within 24-hour window)
+    if (is_gm) {
+        // Must be the creator
+        if (event.created_by !== sessionUserId) {
+            return false;
+        }
+
+        return within24Hours; // FIXED: Use within24Hours instead of canDelete
+    }
+
+    // Non-GM, non-admin, non-developer users cannot delete
+    return false;
+}
+
+// Get time remaining for deletion window
+function getDeletionTimeRemaining(createdAt) {
+    if (!createdAt) return null;
+
+    const created = new Date(createdAt);
+    const now = new Date();
+    const deletionDeadline = new Date(created.getTime() + (24 * 60 * 60 * 1000));
+
+    if (now >= deletionDeadline) {
+        return null; // Window expired
+    }
+
+    const msRemaining = deletionDeadline - now;
+    const hoursRemaining = Math.floor(msRemaining / (1000 * 60 * 60));
+    const minutesRemaining = Math.floor((msRemaining % (1000 * 60 * 60)) / (1000 * 60));
+
+    if (hoursRemaining > 0) {
+        return `${hoursRemaining}h ${minutesRemaining}m remaining`;
+    } else {
+        return `${minutesRemaining}m remaining`;
+    }
+}
+
+// Check if current user can edit an event
+function canUserEditEvent(event) {
+    const is_admin = window.userPermissions?.is_admin || false;
+    const is_developer = window.userPermissions?.is_developer || false;
+    const is_gm = window.userPermissions?.is_gm || false;
+    const sessionUserId = window.currentUserId || 0;
+    return is_admin || is_developer || (is_gm && event.created_by === sessionUserId);
+}
+
+// ============================================
 // GLOBAL EXPORTS
 // ============================================
 window.initializeEventsModule = initializeEventsModule;
 window.loadEvents = loadEvents;
 window.filterEvents = filterEvents;
-window.filterEventsByType = filterEventsByType;
-window.filterEventsByGame = filterEventsByGame;
 
 // Event Modal Functions
 window.openEventModal = openEventModal;
 window.closeEventModal = closeEventModal;
-window.toggleEventSubscription = toggleEventSubscription;
 
 // Day Modal Functions (Calendar)
 window.openDayModal = openDayModal;
@@ -2708,33 +2273,11 @@ window.toggleAllDayEvent = toggleAllDayEvent;
 
 // Edit Event Functions
 window.toggleEditMode = toggleEditMode;
-window.cancelEdit = cancelEdit;
-window.submitEventEdit = submitEventEdit;
 window.handleEditEventTypeChange = handleEditEventTypeChange;
 
 // Delete Event Functions
 window.deleteEvent = deleteEvent;
-window.confirmDeleteEvent = confirmDeleteEvent;
-window.canUserDeleteEvent = canUserDeleteEvent;
-window.getDeletionTimeRemaining = getDeletionTimeRemaining;
-
-// Game Tag System Functions
-window.addGameTag = addGameTag;
-window.removeGameTag = removeGameTag;
-window.clearSelectedGames = clearSelectedGames;
 
 //Filtering with seasons
-window.loadPastSeasonsForFilter = loadPastSeasonsForFilter;
 window.handlePastSeasonSelection = handlePastSeasonSelection;
 window.filterEventsByPastSeason = filterEventsByPastSeason;
-window.filterBySeasonAndType = filterBySeasonAndType;
-window.filterBySeasonAndGame = filterBySeasonAndGame;
-window.loadEventsForPastSeason = loadEventsForPastSeason;
-
-// Utility Functions
-window.loadGamesForFilter = loadGamesForFilter;
-window.clearGamesCache = clearGamesCache;
-
-//Leagues added to modals for match case
-window.handleLeagueFieldVisibility = handleLeagueFieldVisibility;
-window.loadLeaguesForDropdown = loadLeaguesForDropdown;

--- a/EsportsManagementTool/EsportsManagementTool/static/general.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/general.css
@@ -1,7 +1,6 @@
 /* ============================================
    GENERAL STYLES
    Base styles for login, navigation, and profile
-   ORGANIZED BY CLAUDEAI
    ============================================ */
 
 /* --------------------------------------------

--- a/EsportsManagementTool/EsportsManagementTool/static/modals.css
+++ b/EsportsManagementTool/EsportsManagementTool/static/modals.css
@@ -615,7 +615,6 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    width: 90%;
     max-width: 500px;
     padding: 1rem 1.25rem;
     background-color: #1e1e2f;

--- a/EsportsManagementTool/EsportsManagementTool/static/modals.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/modals.js
@@ -38,7 +38,6 @@ const MODAL_CLOSE_HANDLERS = {
 
     // Event-related modals
     'dayEventsModal': () => closeDayModal(),
-    'eventDetailsModal': () => closeEventModal(),
     'createEventModal': () => closeCreateEventModal(),
 
     // Game/Community-related modals

--- a/EsportsManagementTool/EsportsManagementTool/static/modals.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/modals.js
@@ -57,7 +57,7 @@ const MODAL_CLOSE_HANDLERS = {
 
     // Scheduled events
     'scheduleDetailsModal': () => closeScheduleModal(),
-    'createScheduledEventModal': () => closeCreateScheduledEventModal(),
+    'createScheduledEventModal': () => closeCreateScheduleModal(),
 
     // Stats modal
     'recordMatchResultModal': () => closeRecordResultModal(),

--- a/EsportsManagementTool/EsportsManagementTool/static/scheduled-events.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/scheduled-events.js
@@ -1,11 +1,9 @@
 /**
  * ============================================
  * SCHEDULED-EVENTS.JS
- * ORGANIZED BY CLAUDEAI
  * ============================================
  *
  * Manages recurring scheduled events for teams
- * Features:
  * - Create recurring events (Weekly, Biweekly, Monthly, Once)
  * - View and manage team schedules
  * - Edit existing schedules
@@ -22,21 +20,12 @@
  * Tracks current context and loaded data
  */
 const ScheduleState = {
-    /** Currently selected team ID */
     currentTeamId: null,
-
-    /** Currently selected game ID */
     currentGameId: null,
-
-    /** Loaded schedules for current team */
     currentSchedules: [],
+    pendingDeleteScheduleId: null,
 
-    /** Pending schedule deletion ID */
-    pendingDeleteScheduleId: null,  // ADD THIS LINE
-
-    /**
-     * Reset state to defaults
-     */
+    // Reset state to defaults
     reset() {
         this.currentTeamId = null;
         this.currentGameId = null;
@@ -44,21 +33,13 @@ const ScheduleState = {
         this.pendingDeleteScheduleId = null;
     },
 
-    /**
-     * Set current context
-     * @param {number} teamId - Team ID
-     * @param {number} gameId - Game ID
-     */
+    // Set current context
     setContext(teamId, gameId) {
         this.currentTeamId = teamId;
         this.currentGameId = gameId;
     },
 
-    /**
-     * Find schedule by ID
-     * @param {number} scheduleId - Schedule ID to find
-     * @returns {Object|null} Schedule object or null if not found
-     */
+    // Find schedule by ID
     findSchedule(scheduleId) {
         return this.currentSchedules.find(s => s.schedule_id === scheduleId) || null;
     }
@@ -81,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Create scheduled event form submission
     const createForm = document.getElementById('createScheduledEventForm');
     if (createForm) {
-        createForm.addEventListener('submit', handleScheduledEventSubmit);
+        createForm.addEventListener('submit', handleScheduleSubmit);
     }
 
     // Location dropdown for create form
@@ -106,9 +87,6 @@ document.addEventListener('DOMContentLoaded', function() {
 /**
  * Initialize schedule button visibility based on team selection
  * Shows "Schedule Event" button only if user is GM for the team's game
- *
- * @param {number} teamId - ID of the selected team
- * @param {number} gameId - ID of the team's game
  */
 async function initScheduleButton(teamId, gameId) {
     // Update state
@@ -162,12 +140,7 @@ async function initScheduleButton(teamId, gameId) {
 // DATA LOADING & API CALLS
 // ============================================
 
-/**
- * Load all scheduled events for a specific team
- * Fetches schedule data and renders it in the schedule tab
- *
- * @param {number} teamId - ID of the team to load schedules for
- */
+// Load all schedules for a specific team
 async function loadScheduleTab(teamId) {
     const schedulePanel = document.getElementById('scheduleTabContent');
 
@@ -214,13 +187,7 @@ async function loadScheduleTab(teamId) {
     }
 }
 
-/**
- * Update visibility dropdown labels with team and game names
- * Makes visibility options more user-friendly by showing actual names
- *
- * @param {number} teamId - Team ID
- * @param {number} gameId - Game ID
- */
+// Update visibility dropdown labels with team and game names
 async function updateVisibilityLabels(teamId, gameId) {
     try {
         const response = await fetch(`/api/teams/${teamId}/details`);
@@ -254,12 +221,7 @@ async function updateVisibilityLabels(teamId, gameId) {
 // RENDERING FUNCTIONS
 // ============================================
 
-/**
- * Render schedule cards in a two-column grid layout
- * Displays all schedules for the current team
- *
- * @param {Array} schedules - Array of schedule objects to render
- */
+// Render schedule cards
 function renderScheduleCards(schedules) {
     const schedulePanel = document.getElementById('scheduleTabContent');
 
@@ -318,101 +280,11 @@ function renderScheduleCards(schedules) {
 }
 
 // ============================================
-// UTILITY & HELPER FUNCTIONS
-// ============================================
-
-/**
- * Build dynamic frequency text based on schedule settings
- * Formats schedule frequency in a human-readable way
- *
- * @param {Object} schedule - Schedule object
- * @returns {string} Formatted frequency text
- *
- * @example
- * // Returns: "Weekly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
- * buildFrequencyText({ frequency: 'Weekly', day_of_week_name: 'Monday', ... })
- */
-function buildFrequencyText(schedule) {
-    const startTime = schedule.start_time;
-    const endTime = schedule.end_time;
-    const timeRange = `${startTime} - ${endTime}`;
-
-    if (schedule.frequency === 'Once') {
-        // Format: "2025-12-25 from 3:00 PM - 5:00 PM"
-        return `${schedule.specific_date} from ${timeRange}`;
-    } else if (schedule.frequency === 'Monthly') {
-        // Format: "Monthly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
-        return `Monthly / ${schedule.day_of_week_name} / ${timeRange} until ${schedule.schedule_end_date}`;
-    } else if (schedule.frequency === 'Biweekly') {
-        // Format: "Biweekly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
-        return `Biweekly / ${schedule.day_of_week_name} / ${timeRange} until ${schedule.schedule_end_date}`;
-    } else if (schedule.frequency === 'Weekly') {
-        // Format: "Weekly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
-        return `Weekly / ${schedule.day_of_week_name} / ${timeRange} until ${schedule.schedule_end_date}`;
-    } else {
-        // Fallback for unknown frequencies
-        return `${schedule.frequency} - ${schedule.day_of_week_name || 'N/A'}`;
-    }
-}
-
-/**
- * Build dynamic visibility text with game/team context
- * Converts visibility setting to user-friendly text with context
- *
- * @param {Object} schedule - Schedule object with visibility and game info
- * @returns {string} Formatted visibility text
- *
- * @example
- * // Returns: "League of Legends Community"
- * buildVisibilityText({ visibility: 'game_community', game_title: 'League of Legends' })
- */
-function buildVisibilityText(schedule) {
-    const gameName = schedule.game_title;
-
-    switch (schedule.visibility) {
-        case 'game_community':
-            return `${gameName} Community`;
-
-        case 'game_players':
-            return `${gameName} Players`;
-
-        case 'team':
-            // Use team name if available, otherwise show generic message
-            if (schedule.team_name) {
-                return `${schedule.team_name} for ${gameName}`;
-            }
-            return `Team-specific for ${gameName}`;
-
-        default:
-            return formatVisibility(schedule.visibility);
-    }
-}
-
-/**
- * Format visibility setting for display (fallback)
- * Converts internal visibility codes to readable text
- *
- * @param {string} visibility - Visibility setting code
- * @returns {string} Formatted visibility text
- */
-function formatVisibility(visibility) {
-    const visibilityMap = {
-        'team': 'Team Only',
-        'game_players': 'Game Players',
-        'game_community': 'Game Community',
-    };
-    return visibilityMap[visibility] || visibility;
-}
-
-// ============================================
 // CREATE SCHEDULE MODAL
 // ============================================
 
-/**
- * Open the create scheduled event modal
- * Resets form and prepares modal for new schedule creation
- */
-function openCreateScheduledEventModal() {
+// Open the create schedule modal
+function openCreateScheduleModal() {
     if (!ScheduleState.currentTeamId && !currentScheduleTeamId) {
         alert('Please select a team first');
         return;
@@ -475,37 +347,14 @@ function openCreateScheduledEventModal() {
     document.body.style.overflow = 'hidden';
 }
 
-/**
- * Close create scheduled event modal
- */
-function closeCreateScheduledEventModal() {
+// Close create schedule modal
+function closeCreateScheduleModal() {
     const modal = document.getElementById('createScheduledEventModal');
-    if (modal) {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto';
-    }
-
-    const form = document.getElementById('createScheduledEventForm');
-        if (form) {
-            form.reset();
-        }    
-        const leagueGroup = document.getElementById('scheduledLeagueGroup');
-        const dayOfWeekGroup = document.getElementById('scheduledDayOfWeekGroup');
-        const specificDateGroup = document.getElementById('scheduledSpecificDateGroup');
-        const endDateGroup = document.querySelector('label[for="scheduledEndDate"]')?.parentElement;
-
-        if (leagueGroup) leagueGroup.style.display = 'none';
-        if (dayOfWeekGroup) dayOfWeekGroup.style.display = 'block';
-        if (specificDateGroup) specificDateGroup.style.display = 'none';
-        if (endDateGroup) endDateGroup.style.display = 'block';
+    setElementDisplay(modal, 'none');
+    document.body.style.overflow = 'auto';
 }
 
-/**
- * Handle frequency dropdown change
- * Shows/hides appropriate date fields based on frequency selection
- * - Once: Shows specific date, hides day of week and end date
- * - Recurring: Shows day of week and end date, hides specific date
- */
+// Handle frequency dropdown change
 function handleFrequencyChange() {
     const frequency = document.getElementById('scheduledFrequency').value;
     const dayOfWeekGroup = document.getElementById('scheduledDayOfWeekGroup');
@@ -538,13 +387,65 @@ function handleFrequencyChange() {
     }
 }
 
-/**
- * Handle create scheduled event form submission
- * Validates and submits new schedule to server
- *
- * @param {Event} event - Form submit event
- */
-async function handleScheduledEventSubmit(event) {
+// Build dynamic frequency text based on schedule settings
+function buildFrequencyText(schedule) {
+    const startTime = schedule.start_time;
+    const endTime = schedule.end_time;
+    const timeRange = `${startTime} - ${endTime}`;
+
+    if (schedule.frequency === 'Once') {
+        // Format: "2025-12-25 from 3:00 PM - 5:00 PM"
+        return `${schedule.specific_date} from ${timeRange}`;
+    } else if (schedule.frequency === 'Monthly') {
+        // Format: "Monthly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
+        return `Monthly / ${schedule.day_of_week_name} / ${timeRange} until ${schedule.schedule_end_date}`;
+    } else if (schedule.frequency === 'Biweekly') {
+        // Format: "Biweekly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
+        return `Biweekly / ${schedule.day_of_week_name} / ${timeRange} until ${schedule.schedule_end_date}`;
+    } else if (schedule.frequency === 'Weekly') {
+        // Format: "Weekly / Monday / 3:00 PM - 5:00 PM until 2025-12-31"
+        return `Weekly / ${schedule.day_of_week_name} / ${timeRange} until ${schedule.schedule_end_date}`;
+    } else {
+        // Fallback for unknown frequencies
+        return `${schedule.frequency} - ${schedule.day_of_week_name || 'N/A'}`;
+    }
+}
+
+// Build dynamic visibility text with game/team context
+function buildVisibilityText(schedule) {
+    const gameName = schedule.game_title;
+
+    switch (schedule.visibility) {
+        case 'game_community':
+            return `${gameName} Community`;
+
+        case 'game_players':
+            return `${gameName} Players`;
+
+        case 'team':
+            // Use team name if available, otherwise show generic message
+            if (schedule.team_name) {
+                return `${schedule.team_name} for ${gameName}`;
+            }
+            return `Team-specific for ${gameName}`;
+
+        default:
+            return formatVisibility(schedule.visibility);
+    }
+}
+
+// Format visibility setting for display (fallback)
+function formatVisibility(visibility) {
+    const visibilityMap = {
+        'team': 'Team Only',
+        'game_players': 'Game Players',
+        'game_community': 'Game Community',
+    };
+    return visibilityMap[visibility] || visibility;
+}
+
+// Handle create schedule form submission
+async function handleScheduleSubmit(event) {
     event.preventDefault();
 
     const submitBtn = event.target.querySelector('button[type="submit"]');
@@ -563,7 +464,6 @@ async function handleScheduledEventSubmit(event) {
         leagueSelect?.focus();
         return;
     }
-
 
     // Handle location (custom or preset)
     const locationSelect = document.getElementById('scheduledLocation');
@@ -631,7 +531,7 @@ async function handleScheduledEventSubmit(event) {
             btnSpinner.style.display = 'none';
 
             setTimeout(() => {
-                closeCreateScheduledEventModal();
+                closeCreateScheduleModal();
 
                 // Reload team details if function exists
                 if (typeof selectTeam === 'function') {
@@ -657,13 +557,6 @@ async function handleScheduledEventSubmit(event) {
 // ============================================
 // VIEW SCHEDULE MODAL
 // ============================================
-
-/**
- * Open schedule details modal in view mode
- * Displays full information about a specific schedule
- *
- * @param {number} scheduleId - ID of the schedule to display
- */
 async function openScheduleModal(scheduleId) {
     const schedule = ScheduleState.findSchedule(scheduleId) ||
                      currentSchedules.find(s => s.schedule_id === scheduleId);
@@ -696,11 +589,7 @@ async function openScheduleModal(scheduleId) {
     document.body.style.overflow = 'hidden';
 }
 
-/**
- * Render game icon in modal header WITH event count
- * FIXED: Now properly removes event count when viewing one-time schedules
- * @param {Object} schedule - Schedule object with game info
- */
+// Render game icon in modal header WITH event count
 async function renderGameIcon(schedule) {
     const gameIconContainer = document.getElementById('scheduleModalGameIcon');
     const titleElement = document.getElementById('scheduleModalTitle');
@@ -750,11 +639,7 @@ async function renderGameIcon(schedule) {
     }
 }
 
-/**
- * Fetch the count of events associated with a schedule
- * @param {number} scheduleId - Schedule ID
- * @returns {number} Count of associated events
- */
+// Fetch the count of events associated with a schedule
 async function fetchScheduleEventCount(scheduleId) {
     try {
         const response = await fetch(`/api/schedule/${scheduleId}/event-count`);
@@ -770,10 +655,7 @@ async function fetchScheduleEventCount(scheduleId) {
     }
 }
 
-/**
- * Render schedule details in modal body
- * @param {Object} schedule - Schedule object
- */
+// Render schedule details in modal body
 function renderScheduleDetails(schedule) {
     const modalBody = document.getElementById('scheduleModalBody');
     const eventTypeClass = schedule.event_type.toLowerCase();
@@ -862,10 +744,7 @@ if (leagueSelectInit) {
     }
 }
 
-/**
- * Configure edit and delete buttons based on user permissions
- * @param {number} scheduleId - Schedule ID for button actions
- */
+// Configure edit and delete buttons based on user permissions
 async function configureScheduleButtons(scheduleId) {
     const editBtn = document.getElementById('editScheduleBtn');
     const deleteBtn = document.getElementById('deleteScheduleBtn');
@@ -919,9 +798,7 @@ async function configureScheduleButtons(scheduleId) {
     }
 }
 
-/**
- * Close schedule details modal
- */
+// Close schedule details modal
 function closeScheduleModal() {
     const modal = document.getElementById('scheduleDetailsModal');
     if (modal) {
@@ -933,13 +810,6 @@ function closeScheduleModal() {
 // ============================================
 // EDIT SCHEDULE MODAL
 // ============================================
-
-/**
- * Switch schedule modal to edit mode
- * Replaces view content with editable form
- *
- * @param {number} scheduleId - ID of schedule to edit
- */
 function openEditScheduleMode(scheduleId) {
     const schedule = ScheduleState.findSchedule(scheduleId) ||
                      currentSchedules.find(s => s.schedule_id === scheduleId);
@@ -1085,61 +955,7 @@ function openEditScheduleMode(scheduleId) {
     document.getElementById('deleteScheduleBtn').style.display = 'none';
 }
 
-function handleEditEventTypeChange() {
-    const eventType = document.getElementById('editScheduleType');
-    const leagueGroup = document.getElementById('editScheduleLeagueGroup');
-    const leagueSelect = document.getElementById('editScheduleLeagueSelect');
-    const leagueLabel = document.getElementById('editScheduleLeagueLabel');
-    
-    // Add null checks to prevent errors
-    if (!eventType || !leagueGroup || !leagueSelect) {
-        console.warn('Required elements not found in handleEditEventTypeChange');
-        return;
-    }
-    
-    const eventTypeValue = eventType.value;
-    
-    if (eventTypeValue === 'Match') {
-        leagueGroup.style.display = 'block';
-        leagueSelect.setAttribute('required', 'required');
-        
-        if (leagueLabel) {
-            leagueLabel.innerHTML = 'League <span style="color: #ff5252;">*</span>';
-        }
-        
-        // Get team_id from schedule or context - with proper null check
-        const scheduleIdInput = document.getElementById('editScheduleId');
-        if (!scheduleIdInput) {
-            console.warn('Schedule ID input not found');
-            return;
-        }
-        
-        const scheduleId = parseInt(scheduleIdInput.value);
-        const schedule = ScheduleState.findSchedule(scheduleId) ||
-                        currentSchedules.find(s => s.schedule_id === scheduleId);
-        
-        const teamId = schedule?.team_id || ScheduleState.currentTeamId || currentScheduleTeamId;
-        
-        if (teamId && leagueSelect.options.length <= 1) {
-            console.log('Loading leagues for team_id:', teamId);
-            loadEditScheduleLeagues(teamId, schedule?.league_id || null);
-        }
-    } else {
-        leagueGroup.style.display = 'none';
-        leagueSelect.removeAttribute('required');
-        leagueSelect.value = '';
-        
-        if (leagueLabel) {
-            leagueLabel.innerHTML = 'League (Optional)';
-        }
-    }
-}
-
-/**
- * Load leagues for edit modal
- * @param {number} gameId - Game ID to load leagues for
- * @param {number} currentLeagueId - Currently selected league ID (if any)
- */
+// Load leagues for edit modal
 async function loadEditScheduleLeagues(teamId, currentLeagueId) {
     const leagueSelect = document.getElementById('editScheduleLeagueSelect');
     
@@ -1197,10 +1013,7 @@ async function loadEditScheduleLeagues(teamId, currentLeagueId) {
         leagueSelect.disabled = false;
     }
 }
-/**
- * Setup location dropdown handler for edit form
- * Shows/hides custom location input based on selection
- */
+// Setup location dropdown handler for edit form
 function setupEditLocationHandler() {
     const locationSelect = document.getElementById('editScheduleLocation');
     const customLocationGroup = document.getElementById('editCustomLocationGroup');
@@ -1218,20 +1031,12 @@ function setupEditLocationHandler() {
     });
 }
 
-/**
- * Cancel edit mode and return to view mode
- * @param {number} scheduleId - Schedule ID to reload in view mode
- */
+// Cancel edit mode and return to view mode
 function cancelEditSchedule(scheduleId) {
     openScheduleModal(scheduleId);
 }
 
-/**
- * Handle edit schedule form submission
- * Updates schedule with new values
- *
- * @param {Event} event - Form submit event
- */
+// Handle edit schedule form submission
 async function handleEditScheduleSubmit(event) {
     event.preventDefault();
 
@@ -1320,11 +1125,7 @@ async function handleEditScheduleSubmit(event) {
 // DELETE SCHEDULE
 // ============================================
 
-/**
- * Check if current user can delete a schedule
- * @param {Object} schedule - Schedule object with game_id and created_at
- * @returns {boolean} True if user can delete
- */
+// Check if current user can delete a schedule
 async function canUserDeleteSchedule(schedule) {
     const is_developer = window.userPermissions?.is_developer || false;
     const sessionUserId = window.currentUserId || 0;
@@ -1364,11 +1165,7 @@ async function canUserDeleteSchedule(schedule) {
     return false;
 }
 
-/**
- * Get time remaining for deletion window
- * @param {string} createdAt - ISO timestamp of creation
- * @returns {string|null} Human-readable time remaining or null if expired
- */
+// Get time remaining for deletion window
 function getScheduleDeletionTimeRemaining(createdAt) {
     if (!createdAt) return null;
 
@@ -1391,10 +1188,7 @@ function getScheduleDeletionTimeRemaining(createdAt) {
     }
 }
 
-/**
- * Confirm schedule deletion with user
- * Uses universal delete modal system
- */
+// Confirm schedule deletion with user
 function confirmDeleteSchedule(scheduleId) {
     const schedule = ScheduleState.findSchedule(scheduleId) ||
                      currentSchedules.find(s => s.schedule_id === scheduleId);
@@ -1433,47 +1227,9 @@ function confirmDeleteSchedule(scheduleId) {
     });
 }
 
-/**
- * Check if a schedule has any events left and auto-delete if empty
- * Called after deleting individual scheduled events
- * @param {number} scheduleId - Schedule ID to check
- * @returns {Promise<Object>} Cleanup result
- */
-async function checkAndCleanupSchedule(scheduleId) {
-    try {
-        const response = await fetch(`/api/schedule/${scheduleId}/check-and-cleanup`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        });
 
-        const data = await response.json();
 
-        if (data.success && data.deleted) {
-            console.log(`✓ Auto-deleted empty schedule: ${data.schedule_name}`);
-
-            // Show notification to user
-            showScheduleCleanupNotification(data.schedule_name);
-
-            // Reload schedule tab if currently viewing it
-            if (typeof loadScheduleTab === 'function' && currentSelectedTeamId) {
-                loadScheduleTab(currentSelectedTeamId);
-            }
-        }
-
-        return data;
-    } catch (error) {
-        console.error('Error checking schedule cleanup:', error);
-        return { success: false, deleted: false };
-    }
-}
-
-/**
- * Show notification when a schedule is auto-deleted
- * Uses existing notification system with INFO variant
- * @param {string} scheduleName - Name of deleted schedule
- */
+// Show notification when a schedule is auto-deleted
 function showScheduleCleanupNotification(scheduleName) {
     if (typeof window.showInfoMessage === 'function') {
         window.showInfoMessage(
@@ -1487,11 +1243,7 @@ function showScheduleCleanupNotification(scheduleName) {
 // LEAGUE SELECTION FOR MATCHES
 // ============================================
 
-
-/**
- * Show/hide league dropdown based on event type
- * Makes league REQUIRED for Match events
- */
+// Show/hide league dropdown based on event type
 function handleEventTypeChangeForLeague() {
     const eventType = document.getElementById('scheduledEventType').value;
     const leagueGroup = document.getElementById('scheduledLeagueGroup');
@@ -1535,9 +1287,7 @@ function handleEventTypeChangeForLeague() {
     }
 }
 
-/**
- * Load team leagues into the schedule modal dropdown
- */
+// Load team leagues into the schedule modal dropdown
 async function loadTeamLeaguesForSchedule(teamId) {
     const leagueSelect = document.getElementById('scheduledLeagueSelect');
     
@@ -1580,9 +1330,7 @@ async function loadTeamLeaguesForSchedule(teamId) {
     }
 }
 
-/**
- * Execute the schedule deletion (called by universal modal)
- */
+// Execute the schedule deletion (called by universal modal)
 async function confirmDeleteScheduleAction(scheduleId) {
     try {
         const response = await fetch(`/api/schedule/${scheduleId}`, {
@@ -1622,14 +1370,12 @@ async function confirmDeleteScheduleAction(scheduleId) {
     }
 }
 
-/**
- * Handle schedule delete errors
- */
+// Handle schedule delete errors
 function handleScheduleDeleteError(message) {
     if (message.includes('expired') || message.includes('24')) {
-        alert(`⏰ ${message}\n\nOnly developers can delete schedules after 24 hours.`);
+        alert(`${message}\n\nOnly developers can delete schedules after 24 hours.`);
     } else if (message.includes('creator') || message.includes('Manager')) {
-        alert(`🚫 ${message}`);
+        alert(`${message}`);
     } else {
         alert('Error: ' + message);
     }
@@ -1637,41 +1383,21 @@ function handleScheduleDeleteError(message) {
 }
 
 // ============================================
-// MODAL CLICK-OUTSIDE-TO-CLOSE HANDLER (handles scheduledevents modal bugs)
-// ============================================
-window.addEventListener('click', function(event) {
-    const modal = document.getElementById('createScheduledEventModal');
-    if (event.target === modal) {
-        closeCreateScheduledEventModal();
-    }
-});
-
-// ============================================
 // GLOBAL EXPORTS
 // ============================================
-// Export functions to window object for HTML onclick handlers
-
-window.openCreateScheduledEventModal = openCreateScheduledEventModal;
-window.closeCreateScheduledEventModal = closeCreateScheduledEventModal;
-window.initScheduleButton = initScheduleButton;
-window.fetchScheduleEventCount = fetchScheduleEventCount;
-window.handleFrequencyChange = handleFrequencyChange;
+window.openCreateScheduleModal = openCreateScheduleModal;
+window.closeCreateScheduleModal = closeCreateScheduleModal;
 window.openScheduleModal = openScheduleModal;
 window.closeScheduleModal = closeScheduleModal;
+
+//Team tab schedules
+window.initScheduleButton = initScheduleButton;
 window.loadScheduleTab = loadScheduleTab;
+
+//Editing
 window.openEditScheduleMode = openEditScheduleMode;
-window.cancelEditSchedule = cancelEditSchedule;
-window.updateVisibilityLabels = updateVisibilityLabels;
-//Deletion
-window.canUserDeleteSchedule = canUserDeleteSchedule;
-window.getScheduleDeletionTimeRemaining = getScheduleDeletionTimeRemaining;
-window.confirmDeleteSchedule = confirmDeleteSchedule;
-window.confirmDeleteScheduleAction = confirmDeleteScheduleAction;
-window.checkAndCleanupSchedule = checkAndCleanupSchedule;
+window.handleFrequencyChange = handleFrequencyChange;
+
+//Deletion cleanup
 window.showScheduleCleanupNotification = showScheduleCleanupNotification;
-//League Scheduling
-window.handleEventTypeChangeForLeague = handleEventTypeChangeForLeague;
-window.loadTeamLeaguesForSchedule = loadTeamLeaguesForSchedule;
-//Match handling
-window.handleEditEventTypeChange = handleEditEventTypeChange;
-window.loadEditScheduleLeagues = loadEditScheduleLeagues;
+

--- a/EsportsManagementTool/EsportsManagementTool/static/teams.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams.js
@@ -347,7 +347,7 @@ async function loadNextScheduledEvent(teamId, gameId) {
             const event = data.event;
 
             container.innerHTML = `
-                <div class="next-scheduled-event-card" onclick="openEventModal(${event.id})">
+                <div class="next-scheduled-event-card">
                     <div class="next-event-header">
                         <i class="fas fa-calendar-plus"></i>
                         <h4>Next Scheduled Event</h4>

--- a/EsportsManagementTool/EsportsManagementTool/static/teams.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/teams.js
@@ -347,7 +347,7 @@ async function loadNextScheduledEvent(teamId, gameId) {
             const event = data.event;
 
             container.innerHTML = `
-                <div class="next-scheduled-event-card">
+                <div class="next-scheduled-event-card" onclick="navigateToEvent(${event.id})">
                     <div class="next-event-header">
                         <i class="fas fa-calendar-plus"></i>
                         <h4>Next Scheduled Event</h4>

--- a/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
@@ -55,7 +55,7 @@ function attachCharacterCounter(textareaId, maxLength) {
 
     const counter = document.createElement('div');
     counter.className = 'char-counter';
-    counter.textContent = `0 / ${maxLength}`;
+    counter.textContent = `${textarea.value.length} / ${maxLength}`;
 
     textarea.parentNode.insertBefore(counter, textarea.nextSibling);
 

--- a/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
@@ -46,6 +46,7 @@ function enableDropdown(dropdown) {
 
 /**
  * Attach a live character counter to a text area.
+ * Used by events.js, scheduled-events.js, manage-communities.js, dashboard.js, & tournament-results.js
  */
 function attachCharacterCounter(textareaId, maxLength) {
     const textarea = document.getElementById(textareaId);
@@ -62,6 +63,33 @@ function attachCharacterCounter(textareaId, maxLength) {
     textarea.addEventListener('input', function() {
         counter.textContent = `${textarea.value.length} / ${maxLength}`;
     });
+}
+
+/**
+ * Navigates from an event card to the corresponding event on the Event tab.
+ * Used by communities.js & team.js
+ **/
+function navigateToEvent(eventId) {
+    const eventsTab = document.querySelector('[data-tab="events"]');
+    if (eventsTab) {
+        // Same-page: switch to events tab and open the detail panel
+        eventsTab.click();
+        let opened = false;
+        const tryOpen = (attempts = 0) => {
+            if (opened) return;
+            const container = document.getElementById('eventsContainer');
+            if (container && container.style.display !== 'none') {
+                opened = true;
+                openEventDetailPanel(eventId);
+            } else if (attempts < 30) {
+                setTimeout(() => tryOpen(attempts + 1), 150);
+            }
+        };
+        setTimeout(() => tryOpen(), 200);
+    } else {
+        // Cross-page: redirect to dashboard with event param
+        window.location.href = `/dashboard?openEvent=${eventId}`;
+    }
 }
 
 // ========================================
@@ -83,4 +111,6 @@ function debounce(func, wait) {
 //Global Exports
 window.filterListItems = filterListItems;
 window.enableDropdown = enableDropdown;
+window.attachCharacterCounter = attachCharacterCounter;
+window.navigateToEvent = navigateToEvent;
 window.debounce = debounce;

--- a/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
+++ b/EsportsManagementTool/EsportsManagementTool/static/universal-helpers.js
@@ -54,6 +54,12 @@ function attachCharacterCounter(textareaId, maxLength) {
 
     textarea.setAttribute('maxlength', maxLength);
 
+    // Remove any existing counter to avoid duplicates on re-open
+    const existing = textarea.nextElementSibling;
+    if (existing?.classList.contains('char-counter')) {
+        existing.remove();
+    }
+
     const counter = document.createElement('div');
     counter.className = 'char-counter';
     counter.textContent = `${textarea.value.length} / ${maxLength}`;

--- a/EsportsManagementTool/EsportsManagementTool/templates/base.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/base.html
@@ -381,40 +381,6 @@
     </script>
     {% endif %}
 
-    <!-- Event Details Modal -->
-    <div id="eventDetailsModal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 id="eventModalTitle">Event Details</h2>
-                <div style="display: flex; gap: 0.5rem; align-items: center;">
-                    <button id="editEventBtn"
-                            class="btn-edit-event"
-                            style="display: none;"
-                            onclick="toggleEditMode()">
-                        <i class="fas fa-edit"></i>
-                    </button>
-                    <button id="deleteEventBtn"
-                            class="btn-delete-event"
-                            style="display: none;"
-                            onclick="deleteEvent()">
-                        <i class="fas fa-trash"></i>
-                    </button>
-                    <button class="modal-close" onclick="closeEventModal()">
-                        <i class="fas fa-times"></i>
-                    </button>
-                </div>
-            </div>
-            <div class="modal-body" id="eventModalBody">
-                <div id="eventEditForm" style="display: none;"></div>
-                <div id="eventLoadingSpinner" class="loading-spinner">
-                    <i class="fas fa-spinner fa-spin"></i>
-                    <p>Loading event details...</p>
-                </div>
-                <div id="eventDetailsContent" style="display: none;"></div>
-            </div>
-        </div>
-    </div>
-
     <!-- Delete Confirmation Modal -->
     <div id="deleteConfirmModal" class="delete-confirmation-modal">
         <div class="delete-confirmation-content">

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -659,84 +659,131 @@
                 <div>
                     <h2>Events</h2>
                     <p>Manage matches, practices, and community events</p>
+                </div>
 
-                    <div class="event-header-controls">
-                        <!-- Filter Controls Container - NO MORE ROWS, direct children -->
-                        <div class="event-filters-container">
-                            <!-- Column 1, Row 1 -->
-                            <div class="event-filter-dropdown">
-                                <label for="eventFilter">Filter by:</label>
-                                <select id="eventFilter" onchange="filterEvents()">
-                                    <option value="subscribed" {% if not (user.is_admin or user.is_developer or user.is_gm) %}selected{% endif %}>Subscribed Events</option>
-                                    <option value="all" {% if user.is_admin or user.is_developer or user.is_gm %}selected{% endif %}>All Events</option>
-                                    <option value="upcoming">Next 7 days</option>
-                                    <option value="upcoming14">Next 14 days</option>
-                                    <option value="past30">Last 30 days</option>
-                                    {% if user.is_admin or user.is_developer or user.is_gm %}
-                                    <option value="created_by_me">Created by Me</option>
-                                    {% endif %}
-                                    {% if user.is_admin or user.is_developer %}
-                                    <option value="past_season">Past Seasons</option>
-                                    {% endif %}
-                                    <option value="type">Type</option>
-                                    <option value="game">Game</option>
-                                </select>
-                            </div>
+                <div class="event-header-controls">
+                    <!-- Filter Controls Container -->
+                    <div class="event-filters-container">
 
-                            <!-- Column 2, Row 1 -->
-                            <div class="event-filter-dropdown" id="pastSeasonSecondaryFilterContainer" style="display: none;">
-                                <label for="pastSeasonSecondaryFilter">Then by:</label>
-                                <select id="pastSeasonSecondaryFilter" onchange="filterEventsByPastSeason()">
-                                    <option value="all">All Events</option>
-                                    <option value="created_by_me">Created by Me</option>
-                                    <option value="type">Type</option>
-                                    <option value="game">Game</option>
-                                </select>
-                            </div>
+                        <!-- Hidden selects -->
+                        <div style="display:none">
+                            <select id="eventFilter" onchange="filterEvents()">
+                                <option value="subscribed">Subscribed Events</option>
+                                <option value="all" {% if user.is_admin or user.is_developer or user.is_gm %}selected{% endif %}>All Events</option>
+                                <option value="upcoming">Next 7 days</option>
+                                <option value="upcoming14">Next 14 days</option>
+                                <option value="past30">Last 30 days</option>
+                                {% if user.is_admin or user.is_developer or user.is_gm %}<option value="created_by_me">Created by Me</option>{% endif %}
+                                {% if user.is_admin or user.is_developer %}<option value="past_season">Past Seasons</option>{% endif %}
+                                <option value="type">Type</option>
+                                <option value="game">Game</option>
+                            </select>
+                            <select id="pastSeasonSecondaryFilter" onchange="filterEventsByPastSeason()">
+                                <option value="all">All Events</option>
+                                <option value="created_by_me">Created by Me</option>
+                                <option value="type">Type</option>
+                                <option value="game">Game</option>
+                            </select>
+                            <select id="pastSeasonSelect" onchange="handlePastSeasonSelection()">
+                                <option value="">Select Past Season</option>
+                            </select>
+                            <select id="eventTypeFilter" onchange="handleTypeFilterChange()">
+                                <option value="">Select Type</option>
+                                <option value="tournament">Tournament</option>
+                                <option value="match">Match</option>
+                                <option value="practice">Practice</option>
+                                <option value="event">Event</option>
+                                <option value="misc">Misc</option>
+                            </select>
+                            <select id="gameFilter" onchange="handleGameFilterChange()">
+                                <option value="">Select Game</option>
+                            </select>
+                            <div id="gameFilterLoadingIndicator" style="display:none;"></div>
+                            <div id="pastSeasonLoadingIndicator" style="display:none;"></div>
+                            <div id="pastSeasonSecondaryFilterContainer"></div>
+                            <div id="pastSeasonSelectContainer"></div>
+                            <div id="eventTypeFilterContainer"></div>
+                            <div id="gameFilterContainer"></div>
+                        </div>
 
-                            <!-- Column 1, Row 2 -->
-                            <div class="event-filter-dropdown" id="pastSeasonSelectContainer" style="display: none;">
-                                <label for="pastSeasonSelect">Season:</label>
-                                <select id="pastSeasonSelect" onchange="handlePastSeasonSelection()">
-                                    <option value="">Select Past Season</option>
-                                </select>
-                                <div id="pastSeasonLoadingIndicator" style="display: none;">
-                                    <i class="fas fa-spinner fa-spin"></i>
+                        <!-- Box 1: Primary filter -->
+                        <div class="filter-box" id="filterBox1">
+                            <button class="filter-box-btn" id="filterBox1Btn" onclick="toggleFilterBox('filterBox1Panel')">
+                                <span id="filterBox1Label">{% if user.is_admin or user.is_developer or user.is_gm %}All Events{% else %}Subscribed Events{% endif %}</span>
+                                <i class="fas fa-chevron-down"></i>
+                            </button>
+                            <div class="filter-box-panel" id="filterBox1Panel">
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('subscribed', 'Subscribed Events')">Subscribed Events</div>
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('all', 'All Events')">All Events</div>
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming', 'Next 7 Days')">Next 7 Days</div>
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming14', 'Next 14 Days')">Next 14 Days</div>
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('past30', 'Last 30 Days')">Last 30 Days</div>
+                                {% if user.is_admin or user.is_developer or user.is_gm %}
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('created_by_me', 'Created by Me')">Created by Me</div>
+                                {% endif %}
+                                {% if user.is_admin or user.is_developer %}
+                                <div class="filter-box-item filter-box-item--flyout" id="pastSeasonsFlyoutTrigger">
+                                    Past Seasons <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout" id="pastSeasonsFlyout">
+                                        <div class="filter-box-flyout-loading"><i class="fas fa-spinner fa-spin"></i> Loading...</div>
+                                    </div>
                                 </div>
-                            </div>
-
-                            <!-- Column 2, Row 2 -->
-                            <div class="event-filter-dropdown" id="eventTypeFilterContainer" style="display: none;">
-                                <label for="eventTypeFilter">Type:</label>
-                                <select id="eventTypeFilter" onchange="handleTypeFilterChange()">
-                                    <option value="">Select Type</option>
-                                    <option value="tournament">Tournament</option>
-                                    <option value="match">Match</option>
-                                    <option value="practice">Practice</option>
-                                    <option value="event">Event</option>
-                                    <option value="misc">Misc</option>
-                                </select>
-                            </div>
-
-                            <!-- Game Filter - also Column 2, Row 2 (only one shows at a time) -->
-                            <div class="event-filter-dropdown" id="gameFilterContainer" style="display: none;">
-                                <label for="gameFilter">Game:</label>
-                                <select id="gameFilter" onchange="handleGameFilterChange()">
-                                    <option value="">Select Game</option>
-                                </select>
-                                <div id="gameFilterLoadingIndicator" style="display: none;">
-                                    <i class="fas fa-spinner fa-spin"></i>
+                                {% endif %}
+                                <div class="filter-box-item filter-box-item--flyout">
+                                    Type <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout">
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'tournament', 'Tournament')">Tournament</div>
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'match', 'Match')">Match</div>
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'practice', 'Practice')">Practice</div>
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'event', 'Event')">Event</div>
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'misc', 'Misc')">Misc</div>
+                                    </div>
+                                </div>
+                                <div class="filter-box-item filter-box-item--flyout" id="gameFilterFlyoutTrigger1">
+                                    Game <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout" id="gameFilterFlyout1">
+                                        <div class="filter-box-flyout-loading"><i class="fas fa-spinner fa-spin"></i> Loading...</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
 
-                        <!-- Create Event Button (stays in top right) -->
-                        {% if user.is_admin or user.is_developer or user.is_gm %}
-                        <button class="btn btn-primary" onclick="openCreateEventModal()">
-                            <i class="fas fa-plus"></i> Create Event
-                        </button>
-                        {% endif %}
+                        <!-- Box 2: Past season secondary filter (only visible after season selected) -->
+                        <div class="filter-box" id="filterBox2" style="display:none;">
+                            <button class="filter-box-btn" id="filterBox2Btn" onclick="toggleFilterBox('filterBox2Panel')">
+                                <span id="filterBox2Label">All Events</span>
+                                <i class="fas fa-chevron-down"></i>
+                            </button>
+                            <div class="filter-box-panel" id="filterBox2Panel">
+                                <div class="filter-box-item" onclick="applySecondaryFilter('all', 'All Events')">All Events</div>
+                                <div class="filter-box-item" onclick="applySecondaryFilter('created_by_me', 'Created by Me')">Created by Me</div>
+                                <div class="filter-box-item filter-box-item--flyout">
+                                    Type <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout">
+                                        <div class="filter-box-flyout-item" onclick="applySecondaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'tournament', 'Tournament')">Tournament</div>
+                                        <div class="filter-box-flyout-item" onclick="applySecondaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'match', 'Match')">Match</div>
+                                        <div class="filter-box-flyout-item" onclick="applySecondaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'practice', 'Practice')">Practice</div>
+                                        <div class="filter-box-flyout-item" onclick="applySecondaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'event', 'Event')">Event</div>
+                                        <div class="filter-box-flyout-item" onclick="applySecondaryFilterWithSub('type', 'Type', 'eventTypeFilter', 'misc', 'Misc')">Misc</div>
+                                    </div>
+                                </div>
+                                <div class="filter-box-item filter-box-item--flyout" id="gameFilterFlyoutTrigger2">
+                                    Game <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout" id="gameFilterFlyout2">
+                                        <div class="filter-box-flyout-loading"><i class="fas fa-spinner fa-spin"></i> Loading...</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
+
+                    <!-- Create Event Button (stays in top right) -->
+                    {% if user.is_admin or user.is_developer or user.is_gm %}
+                    <button class="btn btn-primary" onclick="openCreateEventModal()">
+                        <i class="fas fa-plus"></i>
+                    </button>
+                    {% endif %}
                 </div>
             </div>
 

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -659,108 +659,119 @@
                 <div>
                     <h2>Events</h2>
                     <p>Manage matches, practices, and community events</p>
+
+                    <div class="event-header-controls">
+                        <!-- Filter Controls Container - NO MORE ROWS, direct children -->
+                        <div class="event-filters-container">
+                            <!-- Column 1, Row 1 -->
+                            <div class="event-filter-dropdown">
+                                <label for="eventFilter">Filter by:</label>
+                                <select id="eventFilter" onchange="filterEvents()">
+                                    <option value="subscribed" {% if not (user.is_admin or user.is_developer or user.is_gm) %}selected{% endif %}>Subscribed Events</option>
+                                    <option value="all" {% if user.is_admin or user.is_developer or user.is_gm %}selected{% endif %}>All Events</option>
+                                    <option value="upcoming">Next 7 days</option>
+                                    <option value="upcoming14">Next 14 days</option>
+                                    <option value="past30">Last 30 days</option>
+                                    {% if user.is_admin or user.is_developer or user.is_gm %}
+                                    <option value="created_by_me">Created by Me</option>
+                                    {% endif %}
+                                    {% if user.is_admin or user.is_developer %}
+                                    <option value="past_season">Past Seasons</option>
+                                    {% endif %}
+                                    <option value="type">Type</option>
+                                    <option value="game">Game</option>
+                                </select>
+                            </div>
+
+                            <!-- Column 2, Row 1 -->
+                            <div class="event-filter-dropdown" id="pastSeasonSecondaryFilterContainer" style="display: none;">
+                                <label for="pastSeasonSecondaryFilter">Then by:</label>
+                                <select id="pastSeasonSecondaryFilter" onchange="filterEventsByPastSeason()">
+                                    <option value="all">All Events</option>
+                                    <option value="created_by_me">Created by Me</option>
+                                    <option value="type">Type</option>
+                                    <option value="game">Game</option>
+                                </select>
+                            </div>
+
+                            <!-- Column 1, Row 2 -->
+                            <div class="event-filter-dropdown" id="pastSeasonSelectContainer" style="display: none;">
+                                <label for="pastSeasonSelect">Season:</label>
+                                <select id="pastSeasonSelect" onchange="handlePastSeasonSelection()">
+                                    <option value="">Select Past Season</option>
+                                </select>
+                                <div id="pastSeasonLoadingIndicator" style="display: none;">
+                                    <i class="fas fa-spinner fa-spin"></i>
+                                </div>
+                            </div>
+
+                            <!-- Column 2, Row 2 -->
+                            <div class="event-filter-dropdown" id="eventTypeFilterContainer" style="display: none;">
+                                <label for="eventTypeFilter">Type:</label>
+                                <select id="eventTypeFilter" onchange="handleTypeFilterChange()">
+                                    <option value="">Select Type</option>
+                                    <option value="tournament">Tournament</option>
+                                    <option value="match">Match</option>
+                                    <option value="practice">Practice</option>
+                                    <option value="event">Event</option>
+                                    <option value="misc">Misc</option>
+                                </select>
+                            </div>
+
+                            <!-- Game Filter - also Column 2, Row 2 (only one shows at a time) -->
+                            <div class="event-filter-dropdown" id="gameFilterContainer" style="display: none;">
+                                <label for="gameFilter">Game:</label>
+                                <select id="gameFilter" onchange="handleGameFilterChange()">
+                                    <option value="">Select Game</option>
+                                </select>
+                                <div id="gameFilterLoadingIndicator" style="display: none;">
+                                    <i class="fas fa-spinner fa-spin"></i>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Create Event Button (stays in top right) -->
+                        {% if user.is_admin or user.is_developer or user.is_gm %}
+                        <button class="btn btn-primary" onclick="openCreateEventModal()">
+                            <i class="fas fa-plus"></i> Create Event
+                        </button>
+                        {% endif %}
+                    </div>
                 </div>
+            </div>
 
-                <div class="event-header-controls">
-                    <!-- Filter Controls Container - NO MORE ROWS, direct children -->
-                    <div class="event-filters-container">
-                        <!-- Column 1, Row 1 -->
-                        <div class="event-filter-dropdown">
-                            <label for="eventFilter">Filter by:</label>
-                            <select id="eventFilter" onchange="filterEvents()">
-                                <option value="subscribed" {% if not (user.is_admin or user.is_developer or user.is_gm) %}selected{% endif %}>Subscribed Events</option>
-                                <option value="all" {% if user.is_admin or user.is_developer or user.is_gm %}selected{% endif %}>All Events</option>
-                                <option value="upcoming">Next 7 days</option>
-                                <option value="upcoming14">Next 14 days</option>
-                                <option value="past30">Last 30 days</option>
-                                {% if user.is_admin or user.is_developer or user.is_gm %}
-                                <option value="created_by_me">Created by Me</option>
-                                {% endif %}
-                                {% if user.is_admin or user.is_developer %}
-                                <option value="past_season">Past Seasons</option>
-                                {% endif %}
-                                <option value="type">Type</option>
-                                <option value="game">Game</option>
-                            </select>
-                        </div>
-
-                        <!-- Column 2, Row 1 -->
-                        <div class="event-filter-dropdown" id="pastSeasonSecondaryFilterContainer" style="display: none;">
-                            <label for="pastSeasonSecondaryFilter">Then by:</label>
-                            <select id="pastSeasonSecondaryFilter" onchange="filterEventsByPastSeason()">
-                                <option value="all">All Events</option>
-                                <option value="created_by_me">Created by Me</option>
-                                <option value="type">Type</option>
-                                <option value="game">Game</option>
-                            </select>
-                        </div>
-
-                        <!-- Column 1, Row 2 -->
-                        <div class="event-filter-dropdown" id="pastSeasonSelectContainer" style="display: none;">
-                            <label for="pastSeasonSelect">Season:</label>
-                            <select id="pastSeasonSelect" onchange="handlePastSeasonSelection()">
-                                <option value="">Select Past Season</option>
-                            </select>
-                            <div id="pastSeasonLoadingIndicator" style="display: none;">
-                                <i class="fas fa-spinner fa-spin"></i>
-                            </div>
-                        </div>
-
-                        <!-- Column 2, Row 2 -->
-                        <div class="event-filter-dropdown" id="eventTypeFilterContainer" style="display: none;">
-                            <label for="eventTypeFilter">Type:</label>
-                            <select id="eventTypeFilter" onchange="handleTypeFilterChange()">
-                                <option value="">Select Type</option>
-                                <option value="tournament">Tournament</option>
-                                <option value="match">Match</option>
-                                <option value="practice">Practice</option>
-                                <option value="event">Event</option>
-                                <option value="misc">Misc</option>
-                            </select>
-                        </div>
-
-                        <!-- Game Filter - also Column 2, Row 2 (only one shows at a time) -->
-                        <div class="event-filter-dropdown" id="gameFilterContainer" style="display: none;">
-                            <label for="gameFilter">Game:</label>
-                            <select id="gameFilter" onchange="handleGameFilterChange()">
-                                <option value="">Select Game</option>
-                            </select>
-                            <div id="gameFilterLoadingIndicator" style="display: none;">
-                                <i class="fas fa-spinner fa-spin"></i>
-                            </div>
-                        </div>
+            <div class="events-layout">
+                <div class="events-list-pane">
+                    <!-- Events Loading State -->
+                    <div id="eventsLoading" style="text-align: center; padding: 2rem;">
+                        <i class="fas fa-spinner fa-spin" style="font-size: 2rem; color: var(--stockton-blue);"></i>
+                        <p>Loading events...</p>
                     </div>
 
-                    <!-- Create Event Button (stays in top right) -->
-                    {% if user.is_admin or user.is_developer or user.is_gm %}
-                    <button class="btn btn-primary" onclick="openCreateEventModal()">
-                        <i class="fas fa-plus"></i> Create Event
-                    </button>
-                    {% endif %}
+                    <!-- Events Grid Container -->
+                    <div id="eventsContainer" style="display: none;">
+                        <!-- Events will be dynamically loaded here -->
+                    </div>
+
+                    <!-- Empty State -->
+                    <div id="eventsEmptyState" class="events-empty-state" style="display: none;">
+                        <div class="events-empty-state-icon">🎮</div>
+                        {% if user.is_admin or user.is_developer or user.is_gm %}
+                        <h3>No Events Found</h3>
+                        <p>Click "Create Event" to add your first event</p>
+                        {% else %}
+                        <h3>No Subscribed Events Found</h3>
+                        <p>Subscribe to events to see them here, or check back later</p>
+                        {% endif %}
+                    </div>
                 </div>
-            </div>
 
-            <!-- Events Loading State -->
-            <div id="eventsLoading" style="text-align: center; padding: 2rem;">
-                <i class="fas fa-spinner fa-spin" style="font-size: 2rem; color: var(--stockton-blue);"></i>
-                <p>Loading events...</p>
-            </div>
-
-            <!-- Events Grid Container -->
-            <div id="eventsContainer" style="display: none;">
-                <!-- Events will be dynamically loaded here -->
-            </div>
-
-            <!-- Empty State -->
-            <div id="eventsEmptyState" class="events-empty-state" style="display: none;">
-                <div class="events-empty-state-icon">🎮</div>
-                {% if user.is_admin or user.is_developer or user.is_gm %}
-                <h3>No Events Found</h3>
-                <p>Click "Create Event" to add your first event</p>
-                {% else %}
-                <h3>No Subscribed Events Found</h3>
-                <p>Subscribe to events to see them here, or check back later</p>
-                {% endif %}
+                <div class="events-detail-pane" id="eventsDetailPane">
+                    <div class="events-detail-placeholder">
+                        <i class="fas fa-calendar-day"></i>
+                        <p>Select an event to view its details here</p>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -1001,7 +1012,7 @@
                                 <!-- Schedule button SECOND -->
                                 <button id="createScheduleBtn"
                                         class="btn btn-create-schedule"
-                                        onclick="openCreateScheduledEventModal()"
+                                        onclick="openCreateScheduleModal()"
                                         style="display: none;">
                                     <i class="fas fa-calendar-plus"></i> Schedule Event
                                 </button>
@@ -1174,7 +1185,7 @@
         <div class="modal-content modal-content-large">
             <div class="modal-header">
                 <h2>Create Scheduled Event</h2>
-                <button class="modal-close" onclick="closeCreateScheduledEventModal()">
+                <button class="modal-close" onclick="closeCreateScheduleModal()">
                     <i class="fas fa-times"></i>
                 </button>
             </div>
@@ -1324,7 +1335,7 @@
                     <div id="scheduledEventMessage" class="form-message" style="display: none;"></div>
 
                     <div class="form-actions">
-                        <button type="button" class="btn btn-secondary" onclick="closeCreateScheduledEventModal()">
+                        <button type="button" class="btn btn-secondary" onclick="closeCreateScheduleModal()">
                             Cancel
                         </button>
                         <button type="submit" class="btn btn-primary">

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -657,8 +657,8 @@
         <div class="content-card">
             <div class="card-header">
                 <div>
-                    <h2>Events</h2>
-                    <p>Manage matches, practices, and community events</p>
+                    <h2>Community Events</h2>
+                    <p>View major SU Esports events, team matches, and more!</p>
                 </div>
 
                 <div class="event-header-controls">
@@ -670,13 +670,13 @@
                             <select id="eventFilter" onchange="filterEvents()">
                                 <option value="subscribed">Subscribed Events</option>
                                 <option value="all" {% if user.is_admin or user.is_developer or user.is_gm %}selected{% endif %}>All Events</option>
+                                {% if user.is_admin or user.is_developer or user.is_gm %}<option value="created_by_me">Created by Me</option>{% endif %}
                                 <option value="upcoming">Next 7 days</option>
                                 <option value="upcoming14">Next 14 days</option>
                                 <option value="past30">Last 30 days</option>
-                                {% if user.is_admin or user.is_developer or user.is_gm %}<option value="created_by_me">Created by Me</option>{% endif %}
-                                {% if user.is_admin or user.is_developer %}<option value="past_season">Past Seasons</option>{% endif %}
                                 <option value="type">Type</option>
                                 <option value="game">Game</option>
+                                {% if user.is_admin or user.is_developer %}<option value="past_season">Past Seasons</option>{% endif %}
                             </select>
                             <select id="pastSeasonSecondaryFilter" onchange="filterEventsByPastSeason()">
                                 <option value="all">All Events</option>
@@ -715,20 +715,12 @@
                             <div class="filter-box-panel" id="filterBox1Panel">
                                 <div class="filter-box-item" onclick="applyPrimaryFilter('subscribed', 'Subscribed Events')">Subscribed Events</div>
                                 <div class="filter-box-item" onclick="applyPrimaryFilter('all', 'All Events')">All Events</div>
-                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming', 'Next 7 Days')">Next 7 Days</div>
-                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming14', 'Next 14 Days')">Next 14 Days</div>
-                                <div class="filter-box-item" onclick="applyPrimaryFilter('past30', 'Last 30 Days')">Last 30 Days</div>
                                 {% if user.is_admin or user.is_developer or user.is_gm %}
                                 <div class="filter-box-item" onclick="applyPrimaryFilter('created_by_me', 'Created by Me')">Created by Me</div>
                                 {% endif %}
-                                {% if user.is_admin or user.is_developer %}
-                                <div class="filter-box-item filter-box-item--flyout" id="pastSeasonsFlyoutTrigger">
-                                    Past Seasons <i class="fas fa-chevron-right"></i>
-                                    <div class="filter-box-flyout" id="pastSeasonsFlyout">
-                                        <div class="filter-box-flyout-loading"><i class="fas fa-spinner fa-spin"></i> Loading...</div>
-                                    </div>
-                                </div>
-                                {% endif %}
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming', 'Next 7 Days')">Next 7 Days</div>
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming14', 'Next 14 Days')">Next 14 Days</div>
+                                <div class="filter-box-item" onclick="applyPrimaryFilter('past30', 'Last 30 Days')">Last 30 Days</div>
                                 <div class="filter-box-item filter-box-item--flyout">
                                     Type <i class="fas fa-chevron-right"></i>
                                     <div class="filter-box-flyout">
@@ -745,6 +737,14 @@
                                         <div class="filter-box-flyout-loading"><i class="fas fa-spinner fa-spin"></i> Loading...</div>
                                     </div>
                                 </div>
+                                {% if user.is_admin or user.is_developer %}
+                                <div class="filter-box-item filter-box-item--flyout" id="pastSeasonsFlyoutTrigger">
+                                    Past Seasons <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout" id="pastSeasonsFlyout">
+                                        <div class="filter-box-flyout-loading"><i class="fas fa-spinner fa-spin"></i> Loading...</div>
+                                    </div>
+                                </div>
+                                {% endif %}
                             </div>
                         </div>
 
@@ -827,13 +827,12 @@
         <div id="createEventModal" class="modal">
             <div class="modal-content modal-content-large">
                 <div class="modal-header">
-                    <h2>Create New Event</h2>
+                    <h2>Create a New Event!</h2>
                     <button class="modal-close" onclick="closeCreateEventModal()">
                         <i class="fas fa-times"></i>
                     </button>
                 </div>
                 <div class="modal-body">
-                    <p class="modal-subtitle">Add a new event or match to the calendar</p>
 
                     <form id="createEventForm" class="event-form-modal">
                         <div class="form-group">
@@ -1010,8 +1009,8 @@
                         <i class="fas fa-shield-alt"></i>
                     </div>
                     <h2>Team Management</h2>
-                    <p>Manage teams, players, and performance data</p>
-                    <p class="welcome-hint">Select a team from the sidebar to view details</p>
+                    <p>View rosters, team schedules, match performances, and more! </p>
+                    <p class="welcome-hint">Select a team from the sidebar (if available) to view details</p>
                 </div>
 
                 <!-- Team Details Content -->

--- a/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
+++ b/EsportsManagementTool/EsportsManagementTool/templates/dashboard.html
@@ -718,9 +718,14 @@
                                 {% if user.is_admin or user.is_developer or user.is_gm %}
                                 <div class="filter-box-item" onclick="applyPrimaryFilter('created_by_me', 'Created by Me')">Created by Me</div>
                                 {% endif %}
-                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming', 'Next 7 Days')">Next 7 Days</div>
-                                <div class="filter-box-item" onclick="applyPrimaryFilter('upcoming14', 'Next 14 Days')">Next 14 Days</div>
-                                <div class="filter-box-item" onclick="applyPrimaryFilter('past30', 'Last 30 Days')">Last 30 Days</div>
+                                <div class="filter-box-item filter-box-item--flyout">
+                                    Timeframe <i class="fas fa-chevron-right"></i>
+                                    <div class="filter-box-flyout">
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilter('upcoming', 'Next 7 Days')">Next 7 Days</div>
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilter('upcoming14', 'Next 14 Days')">Next 14 Days</div>
+                                        <div class="filter-box-flyout-item" onclick="applyPrimaryFilter('past30', 'Last 30 Days')">Last 30 Days</div>
+                                    </div>
+                                </div>
                                 <div class="filter-box-item filter-box-item--flyout">
                                     Type <i class="fas fa-chevron-right"></i>
                                     <div class="filter-box-flyout">
@@ -787,6 +792,8 @@
                 </div>
             </div>
 
+            <div class="sheet-backdrop" id="sheetBackdrop" onclick="closeEventDetailSheet()"></div>
+            <div class="sheet-backdrop" id="filterBackdrop" onclick="closeAllFilterPanels()"></div>
             <div class="events-layout">
                 <div class="events-list-pane">
                     <!-- Events Loading State -->

--- a/EsportsManagementTool/EsportsManagementTool/universal_helpers.py
+++ b/EsportsManagementTool/EsportsManagementTool/universal_helpers.py
@@ -44,31 +44,39 @@ def get_team_game_id(cursor, team_id: int) -> int | None:
     result = cursor.fetchone()
     return result['gameID'] if result else None
 
-def format_time_to_12hr(time_value) -> str | None:
+
+def format_time_raw(time_value) -> str:
     """
-    Convert time object or timedelta to 12-hour format string
-    Used in communities.py, schedules.py, & teams.py
+    Convert time object or timedelta to HH:MM string for use in HTML time inputs.
+    Used in events.py
     """
     if not time_value:
-        return None
-
-    # Handle timedelta (from MySQL TIME type)
+        return ''
     if isinstance(time_value, timedelta):
         total_seconds = int(time_value.total_seconds())
         hours = total_seconds // 3600
         minutes = (total_seconds % 3600) // 60
     else:
-        # Handle time object
         hours = time_value.hour
         minutes = time_value.minute
+    return f"{hours:02d}:{minutes:02d}"
+
+
+def format_time_to_12hr(time_value) -> str | None:
+    """
+    Convert time object or timedelta to 12-hour format string.
+    Used in communities.py, events.py, schedules.py, & teams.py
+    """
+    if not time_value:
+        return None
+    raw = format_time_raw(time_value)
+    hours, minutes = map(int, raw.split(':'))
 
     # Convert to 12-hour format
     period = "AM" if hours < 12 else "PM"
-    display_hour = hours % 12
-    if display_hour == 0:
-        display_hour = 12
-
+    display_hour = hours % 12 or 12
     return f"{display_hour}:{minutes:02d} {period}"
+
 
 def is_all_day_event(start_time: str, end_time: str) -> bool:
     """


### PR DESCRIPTION
This pull request features the complete overhaul of our Events Tab and the events system in several locations. Here are the main changes/improvements (bug fixes not listed for sake of sanity):

- Event Tab redesigned to feature compact cards and an event detail panel on the right side
- Event cards retain color coordination based on type but now only show name, games (with abbreviations), date, and start time
- Event cards scale with screen size, including mobile friendliness
- Event Detail Panel replaces the Event Detail Modal, retaining full edit functionality, all fields, and permissions-based deletion
- Event Detail Panel adds a dynamic banner system based on games attached to the event. No banner removes the placeholder, one banner shows only one banner, and more than one cycles between all banners with animation
- Event Detail Panel uses the new character counter limit for the description when editing
- Create Event button has been consolidated but is otherwise unchanged
- Filter system has been reworked to feature a max of two boxes with dynamic flyouts for options with submenus
- All functionality has been reworked to accomodate mobile devices
- The Next Community Event Card in the communities pages now redirects to the Events Tab
- The Next Scheduled Event Card in the teams tab now redirects to the Events Tab
- Several files have been consolidated heavily, including events.py, events.js, and events.css
- Several bugs have been fixed
- Other files have had minor consolidation or name tweaks